### PR TITLE
Implement core combinators

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Test
         run: |
-          cabal test $CONFIG
+          cabal test $CONFIG --test-options="--color always"
 
       - name: Doc
         run: cabal haddock gigaparsec $CONFIG

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+
+# Vscode/IDE files
+.vscode

--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ stable documentation please consult Hackage directly.
 [Badge-License]: https://img.shields.io/github/license/j-mie6/parsley.svg
 [License]: https://github.com/j-mie6/gigaparsec/blob/main/LICENSE
 [Badge-PVP]: https://img.shields.io/badge/version%20policy-pvp-blue
+
+## Development
+`gigaparsec` is built with [cabal](https://www.haskell.org/cabal/).
+Use `cabal build` to build, and `cabal test` for testing.
+
+

--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -127,7 +127,7 @@ test-suite gigaparsec-test
     build-depends:
         gigaparsec,
         tasty,
-        tasty-expected-failure,
+        --tasty-expected-failure,
         tasty-hunit
         --TODO: property based testing will be useful when we optimise combinators
         --      to test against their base implementations

--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -109,10 +109,13 @@ test-suite gigaparsec-test
     default-language: Haskell2010
 
     -- Modules included in this executable, other than Main.
-    other-modules: Text.Gigaparsec.PrimitiveTests, Text.Gigaparsec.Internal.Test
+    other-modules: Text.Gigaparsec.PrimitiveTests,
+                   Text.Gigaparsec.CharTests,
+                   Text.Gigaparsec.Internal.Test
 
     ghc-options: -Wno-missing-export-lists -Wno-missing-safe-haskell-mode -Wno-safe
                  -Wno-missing-import-lists -Wno-all-missed-specialisations -Wno-type-defaults
+                 -Wno-missing-kind-signatures
 
     -- The interface type and version of the test suite.
     type:             exitcode-stdio-1.0
@@ -126,6 +129,7 @@ test-suite gigaparsec-test
     -- Test dependencies.
     build-depends:
         gigaparsec,
+        containers,
         tasty,
         --tasty-expected-failure,
         tasty-hunit

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -43,7 +43,7 @@ module Text.Gigaparsec (
   -- combinator as a whole fails.
     (<~>), (<:>),
   -- *** Re-exported from "Control.Applicative"
-    (<*>), liftA2, (*>), (<*),
+    (<*>), liftA2, (*>), (<*), (<**>),
   -- * Branching Combinators
   -- | These combinators allow for parsing one alternative or another. All of these combinators are
   -- /left-biased/, which means that the left-hand side of the combinator is tried first: the
@@ -87,7 +87,7 @@ import Text.Gigaparsec.Internal qualified as Internal.State (State(..))
 import Text.Gigaparsec.Internal.RT (runRT)
 
 import Data.Functor (void)
-import Control.Applicative (liftA2, (<|>), empty, many, some) -- liftA2 required until 9.6
+import Control.Applicative (liftA2, (<|>), empty, many, some, (<**>)) -- liftA2 required until 9.6
 import Control.Selective (select, branch)
 
 -- Hiding the Internal module seems like the better bet: nobody needs to see it anyway :)

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -123,9 +123,7 @@ Success "abd" -- first parser does not consume input on failure now
 atomic :: Parsec a -- ^ the parser, @p@, to execute, if it fails, it will not have consumed input.
        -> Parsec a -- ^ a parser that tries @p@, but never consumes input if it fails.
 atomic (Parsec p) = Parsec $ \st ok err ->
-  -- TODO: (where/when) does st.consumed need to be reset?
-  let st' = st { Internal.State.consumed = False }
-  in  p st' ok (const $ err st')
+  p st ok (const $ err st)
 
 {-| This combinator parses its argument @p@, but does not consume input if it succeeds.
 

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -143,7 +143,7 @@ Failure .. -- lookAhead does not roll back input consumed on failure
 lookAhead :: Parsec a -- ^ the parser, @p@, to execute
           -> Parsec a -- ^ a parser that parses @p@ and never consumes input if it succeeds.
 lookAhead (Parsec p) = Parsec $ \st ok err ->
-  p st (const . (`ok` st)) err
+  p st (\x _ -> ok x st) err
 
 {-|
 This combinator parses its argument @p@, and succeeds when @p@ fails and vice-versa, never consuming

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -169,8 +169,7 @@ keyword kw = atomic $ string kw *> notFollowedBy letterOrDigit
 notFollowedBy :: Parsec a  -- ^ the parser, @p@, to execute, it must fail in order for this combinator to succeed.
               -> Parsec () -- ^ a parser which fails when @p@ succeeds and succeeds otherwise, never consuming input.
 notFollowedBy (Parsec p) = Parsec $ \st ok err ->
-  let st' = st { Internal.State.consumed = False }
-  in  p st' (\_ _ -> err st') (\_ -> ok () st')
+  p st (\_ _ -> err st) (\_ -> ok () st)
 
 -- eof is usually `notFollowedBy item`, but this requires annoying cyclic dependencies on Char
 {- This parser only succeeds at the end of the input.

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -122,10 +122,10 @@ Success "abd" -- first parser does not consume input on failure now
 -}
 atomic :: Parsec a -- ^ the parser, @p@, to execute, if it fails, it will not have consumed input.
        -> Parsec a -- ^ a parser that tries @p@, but never consumes input if it fails.
-atomic (Parsec p) = Parsec $ \input ok err ->
-  -- TODO: (where/when) does input.consumed need to be reset?
-  let input' = input { Internal.State.consumed = False }
-  in  p input' ok (const $ err input')
+atomic (Parsec p) = Parsec $ \st ok err ->
+  -- TODO: (where/when) does st.consumed need to be reset?
+  let st' = st { Internal.State.consumed = False }
+  in  p st' ok (const $ err st')
 
 {-| This combinator parses its argument @p@, but does not consume input if it succeeds.
 
@@ -144,9 +144,9 @@ Failure .. -- lookAhead does not roll back input consumed on failure
 -}
 lookAhead :: Parsec a -- ^ the parser, @p@, to execute
           -> Parsec a -- ^ a parser that parses @p@ and never consumes input if it succeeds.
-lookAhead (Parsec p) = Parsec $ \input ok err ->
-  let input' = input { Internal.State.consumed = False }
-  in  p input' (\x _ -> ok x input') err
+lookAhead (Parsec p) = Parsec $ \st ok err ->
+  let st' = st { Internal.State.consumed = False }
+  in  p st' (\x _ -> ok x st') err
 
 {-|
 This combinator parses its argument @p@, and succeeds when @p@ fails and vice-versa, never consuming
@@ -171,9 +171,9 @@ keyword kw = atomic $ string kw *> notFollowedBy letterOrDigit
 -}
 notFollowedBy :: Parsec a  -- ^ the parser, @p@, to execute, it must fail in order for this combinator to succeed.
               -> Parsec () -- ^ a parser which fails when @p@ succeeds and succeeds otherwise, never consuming input.
-notFollowedBy (Parsec p) = Parsec $ \input ok err ->
-  let input' = input { Internal.State.consumed = False }
-  in  p input' (\_ _ -> err input') (\_ -> ok () input')
+notFollowedBy (Parsec p) = Parsec $ \st ok err ->
+  let st' = st { Internal.State.consumed = False }
+  in  p st' (\_ _ -> err st') (\_ -> ok () st')
 
 {-|
 This parser produces @()@ without having any other effect.

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -143,8 +143,7 @@ Failure .. -- lookAhead does not roll back input consumed on failure
 lookAhead :: Parsec a -- ^ the parser, @p@, to execute
           -> Parsec a -- ^ a parser that parses @p@ and never consumes input if it succeeds.
 lookAhead (Parsec p) = Parsec $ \st ok err ->
-  let st' = st { Internal.State.consumed = False }
-  in  p st' (\x _ -> ok x st') err
+  p st (const . (`ok` st)) err
 
 {-|
 This combinator parses its argument @p@, and succeeds when @p@ fails and vice-versa, never consuming

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -82,7 +82,8 @@ module Text.Gigaparsec (
 -- Care MUST be taken to not expose /any/ implementation details from
 -- `Internal`: when they are in the public API, we are locked into them!
 
-import Text.Gigaparsec.Internal (Parsec, unParsec, emptyState)
+import Text.Gigaparsec.Internal (Parsec, Parsec(Parsec), unParsec, emptyState)
+import Text.Gigaparsec.Internal qualified as Internal.State (State(..))
 import Text.Gigaparsec.Internal.RT (runRT)
 
 import Data.Functor (void)
@@ -121,7 +122,10 @@ Success "abd" -- first parser does not consume input on failure now
 -}
 atomic :: Parsec a -- ^ the parser, @p@, to execute, if it fails, it will not have consumed input.
        -> Parsec a -- ^ a parser that tries @p@, but never consumes input if it fails.
-atomic = undefined --TODO:
+atomic (Parsec p) = Parsec $ \input ok err ->
+  -- TODO: (where/when) does input.consumed need to be reset?
+  let input' = input { Internal.State.consumed = False }
+  in  p input' ok (const $ err input')
 
 {-| This combinator parses its argument @p@, but does not consume input if it succeeds.
 
@@ -140,7 +144,9 @@ Failure .. -- lookAhead does not roll back input consumed on failure
 -}
 lookAhead :: Parsec a -- ^ the parser, @p@, to execute
           -> Parsec a -- ^ a parser that parses @p@ and never consumes input if it succeeds.
-lookAhead = undefined --TODO:
+lookAhead (Parsec p) = Parsec $ \input ok err ->
+  let input' = input { Internal.State.consumed = False }
+  in  p input' (\x _ -> ok x input') err
 
 {-|
 This combinator parses its argument @p@, and succeeds when @p@ fails and vice-versa, never consuming
@@ -165,7 +171,9 @@ keyword kw = atomic $ string kw *> notFollowedBy letterOrDigit
 -}
 notFollowedBy :: Parsec a  -- ^ the parser, @p@, to execute, it must fail in order for this combinator to succeed.
               -> Parsec () -- ^ a parser which fails when @p@ succeeds and succeeds otherwise, never consuming input.
-notFollowedBy = undefined --TODO:
+notFollowedBy (Parsec p) = Parsec $ \input ok err ->
+  let input' = input { Internal.State.consumed = False }
+  in  p input' (\_ _ -> err input') (\_ -> ok () input')
 
 {-|
 This parser produces @()@ without having any other effect.

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -82,7 +82,7 @@ module Text.Gigaparsec (
 -- Care MUST be taken to not expose /any/ implementation details from
 -- `Internal`: when they are in the public API, we are locked into them!
 
-import Text.Gigaparsec.Internal (Parsec(Parsec), emptyState, State(input))
+import Text.Gigaparsec.Internal (Parsec(Parsec), emptyState)
 import Text.Gigaparsec.Internal qualified as Internal.State (State(..))
 import Text.Gigaparsec.Internal.RT (runRT)
 
@@ -185,7 +185,7 @@ Success ()
 @since 0.1.0.0
 -}
 eof :: Parsec ()
-eof = Parsec $ \st good bad -> case input st of
+eof = Parsec $ \st good bad -> case Internal.State.input st of
   (:){} -> bad st
   []    -> good () st
 

--- a/src/Text/Gigaparsec/Char.hs
+++ b/src/Text/Gigaparsec/Char.hs
@@ -55,14 +55,13 @@ import Text.Gigaparsec.Internal.Require (require)
 import Data.Bits (Bits((.&.), (.|.)))
 import Data.Char (ord)
 import Data.Char qualified as Char
-import Data.List.NonEmpty as NonEmpty (NonEmpty((:|)), groupWith, sortBy)
+import Data.List.NonEmpty as NonEmpty (NonEmpty((:|)), groupWith, sortWith)
 import Data.Maybe (isJust, fromJust)
 import Data.Monoid (Alt(Alt, getAlt))
 import Data.Set (Set)
 import Data.Set qualified as Set (member, size, findMin, findMax, mapMonotonic)
-import Data.Ord (Down(Down), comparing)
-import Data.Map.Lazy (Map)
-import Data.Map.Lazy qualified as Map (fromSet, toAscList, member)
+import Data.Map (Map)
+import Data.Map qualified as Map (fromSet, toAscList, member)
 
 -------------------------------------------------
 -- Primitives
@@ -158,7 +157,7 @@ Failure ..
 string :: String        -- ^ the string, @s@, to be parsed from the input
        -> Parsec String -- ^ a parser that either parses the string @s@ or fails at the first
                         -- mismatched character.
-string s = require (not (null s)) "cannot pass empty string to `string`" $
+string s = require (not (null s)) "Text.Gigaparsec.Char.string" "cannot pass empty string" $
   traverse char s
 
 -------------------------------------------------
@@ -198,12 +197,12 @@ Failure ..
 oneOf :: Set Char    -- ^ the set of character, @cs@, to check.
       -> Parsec Char -- ^ a parser that parses one of the member of the set @cs@.
 oneOf cs
-  | sz == 0                 = empty
-  | sz == 1                 = char c1
+  | sz == 0                     = empty
+  | sz == 1                     = char c1
   -- if the smallest and largest characters are as far apart
   -- as the size of the set, it must be contiguous
-  | sz == (ord c2 - ord c1) = satisfy (\c -> c1 <= c && c <= c2) <?> Set.mapMonotonic show cs
-  | otherwise               = satisfy (`Set.member` cs) <?> [rangeLabel]
+  | sz == (ord c2 - ord c1 + 1) = satisfy (\c -> c1 <= c && c <= c2) <?> Set.mapMonotonic show cs
+  | otherwise                   = satisfy (`Set.member` cs) <?> [rangeLabel]
   where !sz = Set.size cs
         -- must be left lazy until sz known not to be 0
         c1 = Set.findMin cs
@@ -234,10 +233,10 @@ Failure ..
 noneOf :: Set Char    -- ^ the set, @cs@, of characters to check.
        -> Parsec Char -- ^ a parser that parses one character that is not a member of the set @cs@.
 noneOf cs
-  | sz == 0                 = item
-  | sz == 1                 = satisfy (/= c1) <?> ["anything except " ++ show c1]
-  | sz == (ord c2 - ord c1) = satisfy (\c -> c < c1 || c2 < c) <?> [rangeLabel]
-  | otherwise               = satisfy (not . (`Set.member` cs))
+  | sz == 0                     = item
+  | sz == 1                     = satisfy (/= c1) <?> ["anything except " ++ show c1]
+  | sz == (ord c2 - ord c1 + 1) = satisfy (\c -> c < c1 || c2 < c) <?> [rangeLabel]
+  | otherwise                   = satisfy (not . (`Set.member` cs))
   where !sz = Set.size cs
         -- must be left lazy until sz known not to be 0
         c1 = Set.findMin cs
@@ -289,7 +288,7 @@ Failure ..
 strings :: Set String    -- ^ the strings to try to parse.
         -> Parsec String -- ^ a parser that tries to parse all the given strings returning the
                          -- longest one that matches.
-strings = trie . Map.fromSet pure
+strings = _trie "Text.Gigaparsec.Char.strings" . Map.fromSet pure
 
 -- Departure from original naming, but no overloading, so oh well
 {-|
@@ -329,18 +328,17 @@ trie :: Map String (Parsec a) -- ^ the key-value pairs to try to parse.
      -> Parsec a              -- ^ a parser that tries to parse all the given key-value pairs,
                               -- returning the (possibly failing) result of the value that
                               -- corresponds to the longest matching key.
-trie strs = require (not (Map.member "" strs)) "cannot pass empty string to `strings` or `trie`" $
+trie = _trie "Text.Gigaparsec.Char.trie"
+
+_trie :: String -> Map String (Parsec a) -> Parsec a
+_trie func strs = require (not (Map.member "" strs)) func "the empty string is not a valid key" $
   getAlt $ foldMap combineSameLeading (NonEmpty.groupWith (head . fst) (Map.toAscList strs))
   where -- When combining these parsers it is important to make sure the
         -- longest ones parse first. All but the last parser need an `atomic`.
         combineSameLeading :: NonEmpty (String, Parsec a) -> Alt Parsec a
         combineSameLeading group = foldMap (\(str, p) -> Alt $ atomic (string str) *> p) (reverse rest)
-                               <|> Alt (string longest *> longP)
-          where (longest, longP) :| rest = sortOnInverse (length . fst) group
-
-        sortOnInverse :: Ord b => (a -> b) -> NonEmpty a -> NonEmpty a
-        sortOnInverse f =
-          fmap snd . NonEmpty.sortBy (comparing (Down . fst)) . fmap (\x -> let !y = f x in (y, x))
+                               <|> Alt (string shortest *> shortP)
+          where (shortest, shortP) :| rest = NonEmpty.sortWith (length . fst) group
 
 -------------------------------------------------
 -- Specific Character Parsers

--- a/src/Text/Gigaparsec/Char.hs
+++ b/src/Text/Gigaparsec/Char.hs
@@ -70,8 +70,8 @@ import Data.Map.Lazy qualified as Map (fromSet, toAscList, member)
 {-|
 This combinator tries to parse a single character from the input that matches the given predicate.
 
-Attempts to read a character from the input and tests it against the predicate @pred@. If a character
-@c@ can be read and @pred c@ is true, then @c@ is consumed and returned. Otherwise, no input is
+Attempts to read a character from the input and tests it against the predicate @test@. If a character
+@c@ can be read and @test c@ is true, then @c@ is consumed and returned. Otherwise, no input is
 consumed and this combinator will fail.
 
 ==== __Examples__
@@ -90,14 +90,15 @@ char c = satisfy (== c)
 
 @since 0.1.0.0
 -}
-satisfy :: (Char -> Bool) -- ^ the predicate, @pred@, to test the next character against, should one
+satisfy :: (Char -> Bool) -- ^ the predicate, @test@, to test the next character against, should one
                           -- exist.
-        -> Parsec Char    -- ^ a parser that tries to read a single character @c@, such that @pred c@
+        -> Parsec Char    -- ^ a parser that tries to read a single character @c@, such that @test c@
                           -- is true, or fails.
-satisfy pred = Internal.Parsec $ \input ok err ->
-  case Internal.input input of
-    (x: xs) | pred x  -> ok x (input { Internal.input = xs, Internal.consumed = True })
-    _                 -> err input
+satisfy test = Internal.Parsec $ \st ok err ->
+  case Internal.input st of
+    (x: xs) | test x  ->
+      ok x (st { Internal.input = xs, Internal.consumed = True })
+    _                 -> err st
 
 -- Needs to be primitive for the raw expected item down the line
 {-|

--- a/src/Text/Gigaparsec/Char.hs
+++ b/src/Text/Gigaparsec/Char.hs
@@ -100,12 +100,10 @@ satisfy test = Internal.Parsec $ \st ok err ->
       ok x ((updatePos st x) { Internal.input = xs, Internal.consumed = True })
     _                 -> err st
   where
-    updatePos st x =
-      let (l, c) = updatePos' (Internal.line st, Internal.col st) x
-      in  st { Internal.line = l, Internal.col = c }
-    updatePos' (l, _) '\n' = (l + 1, 1)
-    updatePos' (l, c) '\t' = (l, ((c + 3) .&. (-4)) .|. 1)
-    updatePos' (l, c) _    = (l, c + 1)
+  updatePos st x
+    | x == '\n' = st { Internal.line = Internal.line st + 1, Internal.col = 1 }
+    | x == '\t' = st { Internal.col = (((Internal.col st) + 3) .&. (-4)) .|. 1 }
+    | otherwise = st { Internal.col = Internal.col st + 1 }
 
 -- Needs to be primitive for the raw expected item down the line
 {-|

--- a/src/Text/Gigaparsec/Char.hs
+++ b/src/Text/Gigaparsec/Char.hs
@@ -52,6 +52,7 @@ import Text.Gigaparsec.Errors.Combinator ((<?>))
 import Text.Gigaparsec.Internal qualified as Internal (Parsec(Parsec), State(..))
 import Text.Gigaparsec.Internal.Require (require)
 
+import Data.Bits (Bits((.&.), (.|.)))
 import Data.Char (ord)
 import Data.Char qualified as Char
 import Data.List.NonEmpty as NonEmpty (NonEmpty((:|)), groupWith, sortBy)
@@ -70,8 +71,8 @@ import Data.Map.Lazy qualified as Map (fromSet, toAscList, member)
 {-|
 This combinator tries to parse a single character from the input that matches the given predicate.
 
-Attempts to read a character from the input and tests it against the predicate @test@. If a character
-@c@ can be read and @test c@ is true, then @c@ is consumed and returned. Otherwise, no input is
+Attempts to read a character from the input and tests it against the predicate @pred@. If a character
+@c@ can be read and @pred c@ is true, then @c@ is consumed and returned. Otherwise, no input is
 consumed and this combinator will fail.
 
 ==== __Examples__
@@ -90,15 +91,22 @@ char c = satisfy (== c)
 
 @since 0.1.0.0
 -}
-satisfy :: (Char -> Bool) -- ^ the predicate, @test@, to test the next character against, should one
+satisfy :: (Char -> Bool) -- ^ the predicate, @pred@, to test the next character against, should one
                           -- exist.
-        -> Parsec Char    -- ^ a parser that tries to read a single character @c@, such that @test c@
+        -> Parsec Char    -- ^ a parser that tries to read a single character @c@, such that @pred c@
                           -- is true, or fails.
 satisfy test = Internal.Parsec $ \st ok err ->
   case Internal.input st of
     (x: xs) | test x  ->
-      ok x (st { Internal.input = xs, Internal.consumed = True })
+      ok x ((updatePos st x) { Internal.input = xs, Internal.consumed = True })
     _                 -> err st
+  where
+    updatePos st x =
+      let (l, c) = updatePos' (Internal.line st, Internal.col st) x
+      in  st { Internal.line = l, Internal.col = c }
+    updatePos' (l, _) '\n' = (l + 1, 1)
+    updatePos' (l, c) '\t' = (l, ((c + 3) .&. (-4)) .|. 1)
+    updatePos' (l, c) _    = (l, c + 1)
 
 -- Needs to be primitive for the raw expected item down the line
 {-|

--- a/src/Text/Gigaparsec/Char.hs
+++ b/src/Text/Gigaparsec/Char.hs
@@ -49,7 +49,7 @@ import Text.Gigaparsec (Parsec, atomic, empty, some, many, (<|>))
 import Text.Gigaparsec.Combinator (skipMany)
 import Text.Gigaparsec.Errors.Combinator ((<?>))
 -- We want to use this to make the docs point to the right definition for users.
-import Text.Gigaparsec.Internal qualified as Internal (Parsec(Parsec))
+import Text.Gigaparsec.Internal qualified as Internal (Parsec(Parsec), State(..))
 import Text.Gigaparsec.Internal.Require (require)
 
 import Data.Char (ord)
@@ -94,7 +94,10 @@ satisfy :: (Char -> Bool) -- ^ the predicate, @pred@, to test the next character
                           -- exist.
         -> Parsec Char    -- ^ a parser that tries to read a single character @c@, such that @pred c@
                           -- is true, or fails.
-satisfy _ = Internal.Parsec undefined --TODO:
+satisfy pred = Internal.Parsec $ \input ok err ->
+  case Internal.input input of
+    (x: xs) | pred x  -> ok x (input { Internal.input = xs, Internal.consumed = True })
+    _                 -> err input
 
 -- Needs to be primitive for the raw expected item down the line
 {-|

--- a/src/Text/Gigaparsec/Errors/Combinator.hs
+++ b/src/Text/Gigaparsec/Errors/Combinator.hs
@@ -10,7 +10,8 @@ import Data.Set (Set)
 
 -- the empty set is weird here, do we require non-empty or just make it id?
 label :: Set String -> Parsec a -> Parsec a
-label ls = require (not (any null ls)) "labels cannot be empty" id --TODO:
+label ls =
+  require (not (any null ls)) "Text.Gigaparsec.Errors.Combinator.label" "labels cannot be empty" id --TODO:
 
 {-# INLINE (<?>) #-}
 infix 0 <?>

--- a/src/Text/Gigaparsec/Internal.hs
+++ b/src/Text/Gigaparsec/Internal.hs
@@ -95,8 +95,8 @@ instance Monad Parsec where
 
   (>>=) :: Parsec a -> (a -> Parsec b) -> Parsec b
   Parsec p >>= f = Parsec $ \st ok err ->
-    let ok' x st' = (unParsec (f x)) st' ok err
-    --              ^^^^^^^^^^^^^^^^
+    let ok' x st' = unParsec (f x) st' ok err
+    --              ^^^^^^^^^^^^^^
     -- get the parser obtained from feeding the output of p to f
     in  p st ok' err
 

--- a/src/Text/Gigaparsec/Internal.hs
+++ b/src/Text/Gigaparsec/Internal.hs
@@ -112,14 +112,13 @@ instance Alternative Parsec where
 
   (<|>) :: Parsec a -> Parsec a -> Parsec a
   Parsec p <|> Parsec q = Parsec $ \st ok err ->
-    let ok' x st'
-          | consumed st' = ok x st'
-          | otherwise    = ok x st
+    let !initConsumed = consumed st
+        ok' x st' = ok x (st' { consumed = initConsumed || consumed st' })
           --  ^ revert to old st.consumed if p didn't consume
         err' st'
           | consumed st' = err st'
           --  ^ fail if p failed *and* consumed
-          | otherwise    = q st ok err
+          | otherwise    = q st' ok err
 
     in  p (st { consumed = False }) ok' err'
 

--- a/src/Text/Gigaparsec/Internal.hs
+++ b/src/Text/Gigaparsec/Internal.hs
@@ -118,7 +118,7 @@ instance Alternative Parsec where
         err' st'
           | consumed st' = err st'
           --  ^ fail if p failed *and* consumed
-          | otherwise    = q st' ok err
+          | otherwise    = q (st' { consumed = initConsumed }) ok err
 
     in  p (st { consumed = False }) ok' err'
 

--- a/src/Text/Gigaparsec/Internal/Require.hs
+++ b/src/Text/Gigaparsec/Internal/Require.hs
@@ -1,9 +1,22 @@
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_HADDOCK hide #-}
-module Text.Gigaparsec.Internal.Require (require) where
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+module Text.Gigaparsec.Internal.Require (require, RequirementUnsatisfied) where
 
-import GHC.Stack (HasCallStack)
+import Control.Exception (Exception, throw)
 
-require :: HasCallStack => Bool -> String -> a -> a
-require True _ = id
-require False msg = error ("Requirement unsatisfied: " ++ msg)
+type RequirementUnsatisfied :: *
+data RequirementUnsatisfied = RequirementUnsatisfied { func :: !String
+                                                     , msg :: !String
+                                                     }
+
+instance Show RequirementUnsatisfied where
+  show :: RequirementUnsatisfied -> String
+  show RequirementUnsatisfied{..} = "requirement unsatisfied, " ++ msg ++ " (" ++ func ++ ")"
+
+instance Exception RequirementUnsatisfied
+
+require :: Bool -> String -> String -> a -> a
+require True _ _ = id
+require False func msg = throw (RequirementUnsatisfied func msg)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,9 +2,11 @@ module Main (main) where
 
 import Test.Tasty
 
-import Text.Gigaparsec.PrimitiveTests
+import Text.Gigaparsec.PrimitiveTests qualified as Primitive
+import Text.Gigaparsec.CharTests qualified as Char
 
 main :: IO ()
 main = defaultMain $ testGroup "gigaparsec"
-  [ primitiveTests
+  [ Primitive.tests
+  , Char.tests
   ]

--- a/test/Text/Gigaparsec/CharTests.hs
+++ b/test/Text/Gigaparsec/CharTests.hs
@@ -1,0 +1,208 @@
+{-# LANGUAGE OverloadedLists #-}
+module Text.Gigaparsec.CharTests where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+--import Test.Tasty.ExpectedFailure
+
+import Control.Monad
+import Data.Char
+import Data.Map.Strict qualified as Map
+
+import Text.Gigaparsec
+import Text.Gigaparsec.Char
+import Text.Gigaparsec.Internal.Require
+import Text.Gigaparsec.Internal.Test
+
+tests :: TestTree
+tests = testGroup "Char"
+  [ satisfyTests
+  , charTests
+  , stringTests
+  , satisfyMapTests
+  , oneOfTests
+  , noneOfTests
+  , stringsTests
+  , trieTests
+  ]
+
+satisfyTests :: TestTree
+satisfyTests =
+  testGroup "satisfy should"
+    [ testCase "be pure if it cannot read" $ do
+        pureParse (satisfy (const False))
+        pureParseWith (satisfy (== 'a')) ""
+        pureParseWith (satisfy (== 'a')) "b"
+    , testCase "be impure otherwise" $ impureParseWith (satisfy (== 'a')) "a"
+    , testCase "return the parsed character" $ do
+        parse item "a" @?= Success 'a'
+        parse item "ba" @?= Success 'b'
+        parse item "\NUL" @?= Success '\NUL'
+    , testCase "fail otherwise" $ do
+        ensureFails (satisfy (== 'b')) ""
+        ensureFails item ""
+        ensureFails (satisfy (== 'b')) "a"
+    ]
+
+charTests :: TestTree
+charTests =
+  testGroup "char should"
+    [ testCase "be pure if it cannot read" $ do
+        pureParseWith (char 'a') ""
+        pureParseWith (char 'a') "b"
+    , testCase "be impure otherwise" $ impureParseWith (char 'a') "a"
+    , testCase "return the parsed character" $ parse (char 'a') "a" @?= Success 'a'
+    , testCase "fail otherwise" $ do
+        ensureFails (char 'a') ""
+        ensureFails (char 'a') "b"
+    ]
+
+stringTests :: TestTree
+stringTests =
+  testGroup "string should"
+    [ testCase "reject the empty string" (throws @RequirementUnsatisfied (string ""))
+    , testCase "be pure if it cannot read at all" $ do
+        pureParseWith (string "abc") ""
+        pureParseWith (string "abc") "123"
+    , testCase "be impure if there is a partial read" $ impureParseWith (string "abc") "abd"
+    , testCase "be impure if full read" $ impureParseWith (string "abc") "abc"
+    , testCase "return the parsed string" $ parse (string "123") "123" @?= Success "123"
+    , testCase "fail otherwise" $ do
+        ensureFails (string "123") "124"
+        ensureFails (string "123") "12"
+    ]
+
+satisfyMapTests :: TestTree
+satisfyMapTests =
+  testGroup "satisfyMap should"
+    [ testCase "fail when invalid" $ do
+        ensureFails p ""
+        ensureFails p "a"
+    , testCase "succeed performing the mapping otherwise" $ do
+        parse p "4" @?= Success 4
+        parse p "9" @?= Success 9
+    ]
+  where p = satisfyMap (\c -> digitToInt c <$ guard (isDigit c))
+
+oneOfTests :: TestTree
+oneOfTests =
+  testGroup "oneOf should"
+    [ testCase "fail when given no characters" $ do
+        pureParse p
+        ensureFails p ""
+        ensureFails p "a"
+    , testCase "act like character given one character" $ do
+        pureParseWith q ""
+        pureParseWith q "b"
+        impureParseWith q "a"
+        parse q "a" @?= Success 'a'
+        ensureFails q ""
+        ensureFails q "b"
+    , testCase "parse within a contiguous range" $ do
+        pureParseWith r ""
+        pureParseWith r "a"
+        forM_ @[] ['0'..'9'] $ \c -> do
+          impureParseWith r (pure c)
+          parse r (pure c) @?= Success c
+        ensureFails r "a"
+        ensureFails r "\NUL"
+        ensureFails r ":"
+        ensureFails r "/"
+    , testCase "parse any other sets" $ do
+        pureParseWith s ""
+        pureParseWith s "a"
+        forM_ @[] ['.', ';', ',', ':'] $ \c -> do
+          impureParseWith s (pure c)
+          parse s (pure c) @?= Success c
+        ensureFails s "a"
+        ensureFails s "\NUL"
+    ]
+  where p = oneOf []
+        q = oneOf ['a']
+        r = oneOf ['0' .. '9']
+        s = oneOf ['.', ';', ',', ':']
+
+noneOfTests :: TestTree
+noneOfTests =
+  testGroup "oneOf should"
+    [ testCase "act like item when given no characters" $ do
+        pureParseWith p ""
+        ensureFails p ""
+        parse p "a" @?= Success 'a'
+        parse p "\ACK" @?= Success '\ACK'
+    , testCase "accept all but a specific character" $ do
+        pureParseWith q ""
+        pureParseWith q "a"
+        impureParseWith q "b"
+        parse q "5" @?= Success '5'
+        ensureFails q ""
+        ensureFails q "a"
+    , testCase "parse within a contiguous range" $ do
+        pureParseWith r ""
+        impureParseWith r "a"
+        forM_ @[] ['0'..'9'] $ \c -> do
+          pureParseWith r (pure c)
+          ensureFails r (pure c)
+        parse r "a" @?= Success 'a'
+        parse r "\NUL" @?= Success '\NUL'
+        parse r ":" @?= Success ':'
+        parse r "/" @?= Success '/'
+    , testCase "parse any other sets" $ do
+        pureParseWith s ""
+        impureParseWith s "a"
+        forM_ @[] ['.', ';', ',', ':'] $ \c -> do
+          pureParseWith s (pure c)
+          ensureFails s (pure c)
+        parse s "a" @?= Success 'a'
+        parse s "\NUL" @?= Success '\NUL'
+    ]
+  where p = noneOf []
+        q = noneOf ['a']
+        r = noneOf ['0' .. '9']
+        s = noneOf ['.', ';', ',', ':']
+
+stringsTests :: TestTree
+stringsTests =
+  testGroup "strings should"
+    [ testCase "reject any empty strings" $ throws @RequirementUnsatisfied (strings ["abc", "323", ""])
+    , testCase "have longest match behaviour" $ do
+        parse p "hello" @?= Success "hello"
+        parse p "hell" @?= Success "hell"
+        parse p "he" @?= Success "h"
+        parse p "123" @?= Success "123"
+        parse p "124" @?= Success "1"
+    , testCase "reject anything outside of the set" $ do
+        ensureFails p "543"
+        ensureFails p "good"
+    ]
+  where p = strings ["hell", "hello", "h", "123", "1"]
+
+trieTests :: TestTree
+trieTests =
+  testGroup "trie should"
+    [ testCase "reject any empty strings" $ throws @RequirementUnsatisfied (trie' ["" --> unit])
+    , testCase "have longest match behaviour" $ do
+        parse p "hello" @?= Success "hello"
+        parse p "hell" @?= Success "hell"
+        parse p "h" @?= Success "h"
+        parse p "he" @?= Success "h"
+        parse p "hi" @?= Success "hi"
+        parse p "good" @?= Success "good"
+        parse p "goodby" @?= Success "good"
+        parse p "goodbye" @?= Success "goodbye"
+    , testCase "reject anything outside of the set" $ do
+        ensureFails p "543"
+        ensureFails p "god"
+    ]
+  where p = trie'
+              [ "h" --> atomic (trie' [ "ell" --> trie' ["o" --> pure "hello"]
+                                              <|> pure "hell"
+                                      , "i"   --> pure "hi"
+                                      ])
+                    <|> pure "h"
+              , "good" --> atomic (trie' ["bye" --> pure "goodbye"])
+                       <|> pure "good"
+              ]
+        infix 0 -->
+        (-->) = (,)
+        trie' = trie . Map.fromList

--- a/test/Text/Gigaparsec/CharTests.hs
+++ b/test/Text/Gigaparsec/CharTests.hs
@@ -60,7 +60,7 @@ charTests =
 stringTests :: TestTree
 stringTests =
   testGroup "string should"
-    [ testCase "reject the empty string" (throws @RequirementUnsatisfied (string ""))
+    [ testCase "reject the empty string" (throws @RequirementUnsatisfied (parse (string "") "")) -- don't ask why `string ""` doesn't work all the time
     , testCase "be pure if it cannot read at all" $ do
         pureParseWith (string "abc") ""
         pureParseWith (string "abc") "123"

--- a/test/Text/Gigaparsec/Internal/Test.hs
+++ b/test/Text/Gigaparsec/Internal/Test.hs
@@ -32,5 +32,25 @@ pureParse p = do
   pureParseWith p "a"
   pureParseWith p ":@279"
 
-consumes :: a -> Parsec a
-consumes x = Parsec $ \st good _ -> good x (st { consumed = True})
+-- TODO: could we use quick-check to generate states?
+-- | Tests to ensure that running the parser on the given string does something to the state
+impureParseWith :: HasCallStack => Parsec a -> String -> Assertion
+impureParseWith (Parsec p) inp = do
+  run initSt
+  --run (initSt { consumed = True })
+  run (initSt { line = 10, col = 20 })
+  --run (initSt { consumed = True, line = 10, col = 20 })
+  where initSt = emptyState inp
+        run :: State -> Assertion
+        run st = assertBool (show st ++ " should be altered") (runRT (p st (const return) return) /= st)
+
+-- TODO: could we use quick-check to generate inputs?
+-- | Tests to ensure that running the parser does something to the state
+impureParse :: HasCallStack => Parsec a -> Assertion
+impureParse p = do
+  impureParseWith p ""
+  impureParseWith p "a"
+  impureParseWith p ":@279"
+
+consume :: a -> Parsec a
+consume x = Parsec $ \st good _ -> good x (st { consumed = True})

--- a/test/Text/Gigaparsec/Internal/Test.hs
+++ b/test/Text/Gigaparsec/Internal/Test.hs
@@ -9,7 +9,7 @@ import Text.Gigaparsec
 import Text.Gigaparsec.Internal
 import Text.Gigaparsec.Internal.RT
 
-import Control.Exception (catches, evaluate, Exception, SomeException(..), Handler(..))
+import Control.Exception (catches, evaluate, Exception, SomeException(..), Handler(..), throwIO)
 import Control.Monad (unless)
 import Type.Reflection (typeOf, typeRep)
 
@@ -71,10 +71,11 @@ ensureFails p inp = case parse p inp of
   Failure{} -> return ()
   Success x -> assertFailure ("parser must fail, but produced: " ++ show x)
 
-throws :: forall e a. Exception e => a -> Assertion
+throws :: forall e a. (HasCallStack, Exception e) => a -> Assertion
 throws x = do
   catches (evaluate x >> assertFailure ("expected: " ++ show (typeRep @e)))
-    [ Handler $ \ (!_ :: e) -> return ()
+    [ Handler $ \ ((!_) :: e) -> return ()
+    , Handler $ \ (ex :: HUnitFailure) -> throwIO ex
     , Handler $ \ (SomeException ex) -> assertFailure ("expected: " ++ show (typeRep @e) ++ "\n"
                                                     ++ " but got: " ++ show (typeOf ex))
     ]

--- a/test/Text/Gigaparsec/PrimitiveTests.hs
+++ b/test/Text/Gigaparsec/PrimitiveTests.hs
@@ -2,7 +2,7 @@ module Text.Gigaparsec.PrimitiveTests where
 
 import Test.Tasty
 import Test.Tasty.HUnit
-import Test.Tasty.ExpectedFailure
+--import Test.Tasty.ExpectedFailure
 
 import Text.Gigaparsec
 import Text.Gigaparsec.Internal.Test
@@ -25,7 +25,6 @@ eofTests =
 
 pureTests :: TestTree
 pureTests =
-  ignoreTestBecause "pure not implemented" $
   testGroup "pure should"
     [ testCase "be pure" $ pureParse (pure 5)
     , testCase "produce the given result" $ parse (pure 5) "" @?= Success 5
@@ -33,7 +32,6 @@ pureTests =
 
 emptyTests :: TestTree
 emptyTests =
-  ignoreTestBecause "empty not implemented" $
   testGroup "empty should"
     [ testCase "be pure" $ pureParse empty
     , testCase "fail unconditionally" $ do
@@ -43,7 +41,12 @@ emptyTests =
 
 apTests :: TestTree
 apTests = after AllSucceed "/primitives.pure/ || /primitives.empty/" $
-  ignoreTestBecause "pure, empty, and (<*>) not implemented" $
   testGroup "(<*>) should"
-    [ testCase "" $ pureParse empty
+    [ testCase "be pure if the sub-parsers are" $ pureParse (pure id <*> pure 7)
+    , testCase "be impure if either sub-parser is" $ do
+        impureParse (consume id <*> pure 7)
+        impureParse (pure id <*> consume 7)
+        impureParse (consume id <*> consume 7)
+    , testCase "sequence the left before the right" $ pureParse (empty <*> consume 7)
+    , testCase "be impure if the left is even when right fails" $ impureParse (consume id <*> empty)
     ]

--- a/test/Text/Gigaparsec/PrimitiveTests.hs
+++ b/test/Text/Gigaparsec/PrimitiveTests.hs
@@ -13,8 +13,8 @@ emptyAndPure, emptyPureAndAp :: String
 emptyAndPure = "/primitives.pure/ || /primitives.empty/"
 emptyPureAndAp = emptyAndPure ++ " || /primitives.(<*>)/"
 
-primitiveTests :: TestTree
-primitiveTests = testGroup "primitives"
+tests :: TestTree
+tests = testGroup "primitives"
   [ eofTests
   , pureTests
   , emptyTests

--- a/test/Text/Gigaparsec/PrimitiveTests.hs
+++ b/test/Text/Gigaparsec/PrimitiveTests.hs
@@ -7,18 +7,29 @@ import Test.Tasty.HUnit
 import Text.Gigaparsec
 import Text.Gigaparsec.Internal.Test
 
+import Data.Void
+
+emptyAndPure, emptyPureAndAp :: String
+emptyAndPure = "/primitives.pure/ || /primitives.empty/"
+emptyPureAndAp = emptyAndPure ++ " || /primitives.(<*>)/"
+
 primitiveTests :: TestTree
 primitiveTests = testGroup "primitives"
   [ eofTests
   , pureTests
   , emptyTests
   , apTests
+  , orTests
+  , atomicTests
+  , lookAheadTests
+  , notFollowedByTests
+  -- TODO: _branch, monad, semigroup?
   ]
 
 eofTests :: TestTree
 eofTests =
   testGroup "eof should"
-    [ testCase "fail if input available" $ parse eof "a" @?= Failure
+    [ testCase "fail if input available" $ ensureFails eof "a"
     , testCase "succeed if input ended" $ parse eof "" @?= Success ()
     , testCase "be pure" $ pureParse eof
     ]
@@ -26,8 +37,8 @@ eofTests =
 pureTests :: TestTree
 pureTests =
   testGroup "pure should"
-    [ testCase "be pure" $ pureParse (pure 5)
-    , testCase "produce the given result" $ parse (pure 5) "" @?= Success 5
+    [ testCase "be pure" $ pureParse unit
+    , testCase "produce the given result" $ parse unit "" @?= Success ()
     ]
 
 emptyTests :: TestTree
@@ -35,12 +46,12 @@ emptyTests =
   testGroup "empty should"
     [ testCase "be pure" $ pureParse empty
     , testCase "fail unconditionally" $ do
-        parse @() empty "" @?= Failure
-        parse @() empty "a" @?= Failure
+        ensureFails @Void empty ""
+        ensureFails @Void empty "a"
     ]
 
 apTests :: TestTree
-apTests = after AllSucceed "/primitives.pure/ || /primitives.empty/" $
+apTests = after AllSucceed emptyAndPure $
   testGroup "(<*>) should"
     [ testCase "be pure if the sub-parsers are" $ pureParse (pure id <*> pure 7)
     , testCase "be impure if either sub-parser is" $ do
@@ -49,4 +60,74 @@ apTests = after AllSucceed "/primitives.pure/ || /primitives.empty/" $
         impureParse (consume id <*> consume 7)
     , testCase "sequence the left before the right" $ pureParse (empty <*> consume 7)
     , testCase "be impure if the left is even when right fails" $ impureParse (consume id <*> empty)
+    ]
+
+orTests :: TestTree
+orTests = after AllSucceed emptyPureAndAp $
+  testGroup "(<|>) should"
+    [ testCase "be pure if the left-hand side is pure and succeeds" $
+        pureParse (unit <|> consume ())
+    , testCase "be impure if the left-hand side is impure and succeeds" $
+        impureParse (consume () <|> empty)
+    , testCase "succeed if the left-hand side succeeds" $ do
+        parse (unit <|> empty) "" @?= Success ()
+        parse (consume () <|> empty) "" @?= Success ()
+    , testCase "be pure if the right-hand side succeeds purely" $ pureParse (empty <|> unit)
+    , testCase "be impure if the right-hand side succeeds impurely" $
+        impureParse (empty <|> consume ())
+    , testCase "fail if both sides fail" $ ensureFails @Void (empty <|> empty) ""
+    , testCase "be impure if the left-hand side is impure and fails" $
+        impureParse (consume () <~> empty <|> empty)
+    , testCase "fail if the left-hand side fails impurely" $
+        ensureFails (consume () <**> empty <|> unit) ""
+    ]
+
+atomicTests :: TestTree
+atomicTests = after AllSucceed emptyPureAndAp $
+  testGroup "atomic should"
+    [ testCase "be pure if the argument is pure" $ do
+        pureParse (atomic unit)
+        pureParse (atomic empty)
+    , testCase "be impure if the argument is impure and succeeds" $
+        impureParse (atomic (consume ()))
+    , testCase "be pure if the argument fails, even if impure" $
+        pureParse (atomic (consume () <**> empty))
+    , testCase "not alter failure characteristics of argument" $ do
+        parse (atomic (consume ())) "" @?= Success ()
+        parse (atomic unit) "" @?= Success ()
+        ensureFails @Void (atomic empty) ""
+        ensureFails (atomic (consume () <* empty)) ""
+    ]
+
+lookAheadTests :: TestTree
+lookAheadTests = after AllSucceed emptyPureAndAp $
+  testGroup "lookAhead should"
+    [ testCase "be pure if the argument is pure" $ do
+        pureParse (lookAhead unit)
+        pureParse (lookAhead empty)
+    , testCase "be pure if the argument is impure and succeeds" $ do
+        pureParse (lookAhead (consume ()))
+    , testCase "be impure if the argument is impure and fails" $ do
+        impureParse (lookAhead (consume () <* empty))
+    , testCase "not alter failure characteristics of argument" $ do
+        parse (lookAhead (pure 7)) "" @?= Success 7
+        parse (lookAhead (consume 14)) "" @?= Success 14
+        ensureFails @Void (lookAhead empty) ""
+        ensureFails (lookAhead (consume () <* empty)) ""
+    ]
+
+notFollowedByTests :: TestTree
+notFollowedByTests = after AllSucceed emptyPureAndAp $
+  testGroup "notFollowedBy should"
+    [ testCase "should always be pure" $ do
+        pureParse (notFollowedBy unit)
+        pureParse (notFollowedBy empty)
+        pureParse (notFollowedBy (consume ()))
+        pureParse (notFollowedBy (consume () *> empty))
+    , testCase "should succeed if the argument fails" $ do
+        parse (notFollowedBy empty) "" @?= Success ()
+        parse (notFollowedBy (consume () *> empty)) "" @?= Success ()
+    , testCase "should fail if the argument succeeds" $ do
+        ensureFails (notFollowedBy unit) ""
+        ensureFails (notFollowedBy (consume ())) ""
     ]


### PR DESCRIPTION
We aim to implement the primitive combinators for gigaparsec, and and typeclass instances for `Parsec`. 
This will provide an mvp that one can actually run.
Combinators to implement:
- `satisfy`
- `atomic`
- `lookAhead`
- `notFollowedBy`

Typeclass instances for the `Parsec` type:
- `Applicative`
- `Selective` (via the internal function `_branch`)
- `Monad`
- `Alternative`