### PR TITLE
Added `manyMap` and `someMap` combinators

### DIFF
--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -127,7 +127,8 @@ test-suite gigaparsec-test
     default-language: Haskell2010
 
     -- Modules included in this executable, other than Main.
-    other-modules: Text.Gigaparsec.PrimitiveTests,
+    other-modules: Text.Gigaparsec.GigaparsecTests,
+                   Text.Gigaparsec.PrimitiveTests,
                    Text.Gigaparsec.CharTests,
                    Text.Gigaparsec.CombinatorTests,
                    Text.Gigaparsec.DebugTests,

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -201,6 +201,7 @@ parsers that consume input to backtrack when they fail (with '(<|>)'). It should
 used for the latter purpose sparingly, however, since excessive backtracking in a
 parser can result in much lower efficiency.
 
+==== __Examples__
 >>> parse (string "abc" <|> string "abd") "abd"
 Failure .. -- first parser consumed a, so no backtrack
 >>> parse (atomic (string "abc") <|> string "abd") "abd"
@@ -320,6 +321,10 @@ in some 'Monoid' @m@. These values are then combined together to form a
 single value; if @p@ could not be parsed, it will return the 'mempty'
 for @m@.
 
+==== __Examples__
+>>> parse (manyMap Set.singleton item) "aaaab"
+Success (Set.fromList ['a', 'b'])
+
 @since 0.2.2.0
 -}
 manyMap :: Monoid m
@@ -335,6 +340,12 @@ The parser @manyMap f p@, will parse @p@ __one__ or more times, then
 adapt each result with the function @f@ to produce a bunch of values
 in some 'Semigroup' @s@. These values are then combined together to form a
 single value.
+
+==== __Examples__
+>>> parse (someMap Max item) "bdcjb"
+Success (Max 'j')
+>>> parse (someMap Min item) "bdcjb"
+Success (Max 'b')
 
 @since 0.2.2.0
 -}

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -311,10 +311,37 @@ manyl f k = _repl f (pure k)
 somel :: (b -> a -> b) -> b -> Parsec a -> Parsec b
 somel f k p = _repl f (f k <$> p) p
 
-manyMap :: Monoid m => (a -> m) -> Parsec a -> Parsec m
+{-|
+This combinator acts like the 'foldMap' function but with a parser.
+
+The parser @manyMap f p@, will parse @p@ __zero__ or more times, then
+adapt each result with the function @f@ to produce a bunch of values
+in some 'Monoid' @m@. These values are then combined together to form a
+single value; if @p@ could not be parsed, it will return the 'mempty'
+for @m@.
+
+@since 0.2.2.0
+-}
+manyMap :: Monoid m
+        => (a -> m) -- injection function for parser results into a monoid
+        -> Parsec a -- parser to execute multiple times
+        -> Parsec m
 manyMap f = manyr (<>) mempty . fmap f
 
-someMap :: Semigroup m => (a -> m) -> Parsec a -> Parsec m
+{-|
+This combinator acts like the 'foldMap' function but with a parser.
+
+The parser @manyMap f p@, will parse @p@ __one__ or more times, then
+adapt each result with the function @f@ to produce a bunch of values
+in some 'Semigroup' @s@. These values are then combined together to form a
+single value.
+
+@since 0.2.2.0
+-}
+someMap :: Semigroup s
+        => (a -> s) -- injection function for parser results into a monoid
+        -> Parsec a -- parser to execute multiple times
+        -> Parsec s
 someMap f p = _repl (<>) (f <$> p) (f <$> p) -- is there a better implementation, it's tricky!
 
 _repl :: (b -> a -> b) -> Parsec b -> Parsec a -> Parsec b

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -72,7 +72,7 @@ module Text.Gigaparsec (
   -- or the first successful result is the initial accumulator (for the reduces). These are
   -- implemented efficiently and do not need to construct any intermediate list with which to store
   -- the results.
-    many, some, manyl, manyr, somel, somer, -- TODO: these need to be properly categorised
+    many, some, manyl, manyr, somel, somer, manyMap, someMap,-- TODO: these need to be properly categorised
   ) where
 
 -- NOTE:
@@ -310,6 +310,12 @@ manyl f k = _repl f (pure k)
 
 somel :: (b -> a -> b) -> b -> Parsec a -> Parsec b
 somel f k p = _repl f (f k <$> p) p
+
+manyMap :: Monoid m => (a -> m) -> Parsec a -> Parsec m
+manyMap f = manyr (<>) mempty . fmap f
+
+someMap :: Semigroup m => (a -> m) -> Parsec a -> Parsec m
+someMap f p = _repl (<>) (f <$> p) (f <$> p) -- is there a better implementation, it's tricky!
 
 _repl :: (b -> a -> b) -> Parsec b -> Parsec a -> Parsec b
 _repl f k p = k <**> manyr (\x next !acc -> next (f acc x)) id p

--- a/test/Text/Gigaparsec/GigaparsecTests.hs
+++ b/test/Text/Gigaparsec/GigaparsecTests.hs
@@ -1,0 +1,42 @@
+module Text.Gigaparsec.GigaparsecTests where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+--import Test.Tasty.ExpectedFailure
+
+import Text.Gigaparsec
+import Text.Gigaparsec.Char
+import Text.Gigaparsec.Internal.Test
+
+import Data.Monoid
+import Data.Semigroup
+import Data.Char (digitToInt)
+import Data.Set (singleton, fromList)
+
+tests :: TestTree
+tests = testGroup "gigaparsec"
+  [ manyMapTests
+  , someMapTests
+  ]
+
+manyMapTests :: TestTree
+manyMapTests = testGroup "manyMap should"
+  [ testCase "should treat (: []) as an identity" do
+      testParse (manyMap (: []) item) "acbdefh324" @?= Success "acbdefh324"
+      testParse (manyMap (: []) item) "" @?= Success ""
+  , testCase "should allow for collapsing into any monoid" do
+      testParse (manyMap (Sum . digitToInt) digit) "1234" @?= Success 10
+      testParse (manyMap (Product . digitToInt) digit) "1234" @?= Success 24
+      testParse (manyMap singleton item) "1234aaa43" @?= Success (fromList ['1', '2', '3', '4', 'a'])
+  ]
+
+someMapTests :: TestTree
+someMapTests = testGroup "someMap should"
+  [ testCase "should treat (: []) as an identity" do
+      testParse (someMap (: []) item) "abcdef123" @?= Success "abcdef123"
+      ensureFails (someMap (: []) item) ""
+  , testCase "should allow for collapsing into any semi-group" do
+      testParse (someMap Max item) "adehfizs" @?= Success (Max 'z')
+      testParse (someMap Min item) "adehfizs" @?= Success (Min 'a')
+      testParse (someMap singleton item) "aaabbbccc" @?= Success (fromList ['a', 'b', 'c'])
+  ]


### PR DESCRIPTION
Closes #12 by implementing the mentioned combinators, which can be used to parse directly into monoidal and semigroupal structures.