### PR TITLE
Refactor CanHold(Un)Signed Typeclass Instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.2.2.0 -- TBD
 
 * Added `manyMap` and `someMap` combinators.
+* Added `filterS` and `mapMaybeS` combinators.
+* Added `Text.Gigaparsec.Position` module.
+* Added `Text.Gigaparsec.Token` and associated functionality.
 
 ## 0.2.1.0 -- 2023-11-14
 

--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -143,8 +143,8 @@ test-suite gigaparsec-test
                    Text.Gigaparsec.ErrorsTests,
                    Text.Gigaparsec.Expr.ChainTests,
                    Text.Gigaparsec.Expr.InfixTests,
-                   --Text.Gigaparsec.TokenTests,
-                   --Text.Gigaparsec.Token.NamesTests,
+                   Text.Gigaparsec.TokenTests,
+                   Text.Gigaparsec.Token.NamesTests,
                    Text.Gigaparsec.Internal.Test,
                    Text.Gigaparsec.Internal.TestError,
                    Text.Gigaparsec.Internal.PlainString

--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -68,7 +68,7 @@ common extensions
     -- Extensions we want enabled without having to specify them
     default-extensions: ScopedTypeVariables, RankNTypes, BangPatterns, TypeApplications,
                         MultiWayIf, DerivingStrategies, InstanceSigs, StandaloneKindSignatures,
-                        ImportQualifiedPost
+                        ImportQualifiedPost, RecordWildCards
 
 common base
     -- Other library packages from which modules are imported.
@@ -93,8 +93,10 @@ library
                       Text.Gigaparsec.Expr.Subtype,
                       Text.Gigaparsec.Position,
                       Text.Gigaparsec.Token.Descriptions,
+                      Text.Gigaparsec.Token.Generic,
                       Text.Gigaparsec.Token.Lexer,
                       Text.Gigaparsec.Token.Names,
+                      Text.Gigaparsec.Token.Numeric,
                       Text.Gigaparsec.Token.Patterns,
                       Text.Gigaparsec.Token.Symbol,
                       Text.Gigaparsec.Registers,

--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -93,6 +93,8 @@ library
                       Text.Gigaparsec.Expr.Subtype,
                       Text.Gigaparsec.Token.Descriptions,
                       Text.Gigaparsec.Token.Lexer,
+                      Text.Gigaparsec.Token.Patterns,
+                      Text.Gigaparsec.Token.Symbol,
                       Text.Gigaparsec.Registers,
 
                       -- Internals
@@ -104,7 +106,8 @@ library
     -- this can probably be loosened?
     build-depends:    containers      >= 0.6 && < 0.7,
                       selective       >= 0.6 && < 0.8,
-                      pretty-terminal >= 0.1.0   && < 0.2
+                      pretty-terminal >= 0.1.0   && < 0.2,
+                      template-haskell
 
     -- Modules included in this library but not exported.
     -- other-modules:

--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -93,6 +93,7 @@ library
                       Text.Gigaparsec.Expr.Subtype,
                       Text.Gigaparsec.Token.Descriptions,
                       Text.Gigaparsec.Token.Lexer,
+                      Text.Gigaparsec.Token.Names,
                       Text.Gigaparsec.Token.Patterns,
                       Text.Gigaparsec.Token.Symbol,
                       Text.Gigaparsec.Registers,

--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -99,6 +99,7 @@ library
                       Text.Gigaparsec.Token.Numeric,
                       Text.Gigaparsec.Token.Patterns,
                       Text.Gigaparsec.Token.Symbol,
+                      Text.Gigaparsec.Token.Text,
                       Text.Gigaparsec.Registers,
 
                       -- Internals

--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -91,6 +91,7 @@ library
                       Text.Gigaparsec.Expr.Chain,
                       Text.Gigaparsec.Expr.Infix,
                       Text.Gigaparsec.Expr.Subtype,
+                      Text.Gigaparsec.Position,
                       Text.Gigaparsec.Token.Descriptions,
                       Text.Gigaparsec.Token.Lexer,
                       Text.Gigaparsec.Token.Names,
@@ -142,6 +143,8 @@ test-suite gigaparsec-test
                    Text.Gigaparsec.ErrorsTests,
                    Text.Gigaparsec.Expr.ChainTests,
                    Text.Gigaparsec.Expr.InfixTests,
+                   --Text.Gigaparsec.TokenTests,
+                   --Text.Gigaparsec.Token.NamesTests,
                    Text.Gigaparsec.Internal.Test,
                    Text.Gigaparsec.Internal.TestError,
                    Text.Gigaparsec.Internal.PlainString

--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -91,6 +91,8 @@ library
                       Text.Gigaparsec.Expr.Chain,
                       Text.Gigaparsec.Expr.Infix,
                       Text.Gigaparsec.Expr.Subtype,
+                      Text.Gigaparsec.Token.Descriptions,
+                      Text.Gigaparsec.Token.Lexer,
                       Text.Gigaparsec.Registers,
 
                       -- Internals

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -64,6 +64,7 @@ module Text.Gigaparsec (
   -- | These combinators perform filtering on the results of a parser. This means that, given the
   -- result of a parser, they will perform some function on that result, and the success of that
   -- function effects whether or not the parser fails.
+    filterS, mapMaybeS,
 
   -- * Folding Combinators
   -- | These combinators repeatedly execute a parser (at least zero or one times depending on the
@@ -357,3 +358,19 @@ someMap f p = _repl (<>) (f <$> p) (f <$> p) -- is there a better implementation
 
 _repl :: (b -> a -> b) -> Parsec b -> Parsec a -> Parsec b
 _repl f k p = k <**> manyr (\x next !acc -> next (f acc x)) id p
+
+-- should these be implemented with branch? probably not.
+{-
+
+@since 0.2.2.0
+-}
+filterS :: (a -> Bool) -> Parsec a -> Parsec a
+filterS f p = p >>= \x -> if f x then pure x else empty
+
+-- this is called mapFilter in Scala... there is no collect counterpart
+{-
+
+@since 0.2.2.0
+-}
+mapMaybeS :: (a -> Maybe b) -> Parsec a -> Parsec b
+mapMaybeS f p = p >>= maybe empty pure . f

--- a/src/Text/Gigaparsec.hs
+++ b/src/Text/Gigaparsec.hs
@@ -89,6 +89,8 @@ import Text.Gigaparsec.Internal.RT qualified as Internal (RT, runRT, rtToIO)
 import Text.Gigaparsec.Internal.Errors qualified as Internal (ParseError, ExpectItem(ExpectEndOfInput), fromParseError)
 
 import Text.Gigaparsec.Errors.ErrorBuilder (ErrorBuilder)
+import Text.Gigaparsec.Errors.Combinator (amend, emptyWide)
+import Text.Gigaparsec.Position (withWidth)
 
 import Data.Functor (void)
 import Control.Applicative (liftA2, (<|>), empty, many, some, (<**>)) -- liftA2 required until 9.6
@@ -365,7 +367,7 @@ _repl f k p = k <**> manyr (\x next !acc -> next (f acc x)) id p
 @since 0.2.2.0
 -}
 filterS :: (a -> Bool) -> Parsec a -> Parsec a
-filterS f p = p >>= \x -> if f x then pure x else empty
+filterS f p = amend $ withWidth p >>= \(x, w) -> if f x then pure x else emptyWide w
 
 -- this is called mapFilter in Scala... there is no collect counterpart
 {-
@@ -373,4 +375,4 @@ filterS f p = p >>= \x -> if f x then pure x else empty
 @since 0.2.2.0
 -}
 mapMaybeS :: (a -> Maybe b) -> Parsec a -> Parsec b
-mapMaybeS f p = p >>= maybe empty pure . f
+mapMaybeS f p = amend $ withWidth p >>= \(x, w) -> maybe (emptyWide w) pure (f x)

--- a/src/Text/Gigaparsec/Combinator.hs
+++ b/src/Text/Gigaparsec/Combinator.hs
@@ -22,7 +22,7 @@ module Text.Gigaparsec.Combinator (
   -- parser succeeds, depending on the combinator. Depending on the combinator, all of the results produced by the
   -- repeated execution of the parser may be returned in a @[]@. These are almost essential for any practical parsing
   -- task.
-    manyN, skipMany, skipSome, skipManyN, count, count1, manyTill, someTill,
+    manyN, skipMany, skipSome, skipManyN, count, count1, manyTill, someTill, skipManyTill, skipSomeTill,
 
   -- * Optional Parsing Combinators
   -- | These combinators allow for the /possible/ parsing of some parser. If the parser succeeds, that is ok
@@ -53,7 +53,7 @@ module Text.Gigaparsec.Combinator (
   ) where
 
 import Text.Gigaparsec (Parsec, many, some, (<|>), ($>), (<:>), select,
-                        branch, empty, unit, manyl, somel, notFollowedBy, liftA2)
+                        branch, empty, unit, manyl, somel, notFollowedBy, liftA2, void)
 import Data.Foldable (asum, sequenceA_)
 
 {-|
@@ -554,6 +554,12 @@ someTill :: Parsec a   -- ^ @p@, the parser to execute multiple times.
          -> Parsec end -- ^ @end@, the parser that stops the parsing of @p@.
          -> Parsec [a] -- ^ a parser that parses @p@ until @end@ succeeds, returning the list of all the successful results.
 someTill p end = notFollowedBy end *> (p <:> manyTill p end)
+
+skipManyTill :: Parsec a -> Parsec end -> Parsec ()
+skipManyTill p end = void (manyTill p end)
+
+skipSomeTill :: Parsec a -> Parsec end -> Parsec ()
+skipSomeTill p end = void (someTill p end)
 
 -- this is ifP
 {-|

--- a/src/Text/Gigaparsec/Debug.hs
+++ b/src/Text/Gigaparsec/Debug.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE ExistentialQuantification, RecordWildCards, NamedFieldPuns #-}
+{-# LANGUAGE ExistentialQuantification, NamedFieldPuns #-}
 {-|
 Module      : Text.Gigaparsec.Debug
 Description : This module contains the very useful debugging combinator, as well as breakpoints.

--- a/src/Text/Gigaparsec/Errors/Combinator.hs
+++ b/src/Text/Gigaparsec/Errors/Combinator.hs
@@ -71,8 +71,8 @@ filtering combinators, but are a little more verbose to use.
 
 import Prelude hiding (fail)
 
-import Text.Gigaparsec (Parsec)
 -- We want to use this to make the docs point to the right definition for users.
+import Text.Gigaparsec.Internal (Parsec)
 import Text.Gigaparsec.Internal qualified as Internal (Parsec(Parsec), line, col, emptyErr, specialisedErr, raise, unexpectedErr, hints, consumed, useHints, adjustErr, hints, hintsValidOffset)
 import Text.Gigaparsec.Internal.Errors (ParseError, CaretWidth(FlexibleCaret, RigidCaret), ExpectItem(ExpectNamed))
 import Text.Gigaparsec.Internal.Errors qualified as Internal (setLexical, amendErr, entrenchErr, dislodgeErr, partialAmendErr, labelErr, explainErr)

--- a/src/Text/Gigaparsec/Internal.hs
+++ b/src/Text/Gigaparsec/Internal.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE DeriveFunctor, StandaloneDeriving, RecordWildCards, NamedFieldPuns, CPP #-}
+{-# LANGUAGE DeriveFunctor, StandaloneDeriving, NamedFieldPuns, CPP #-}
 #include "portable-unlifted.h"
 {-# OPTIONS_HADDOCK hide #-}
 {-|

--- a/src/Text/Gigaparsec/Internal/Require.hs
+++ b/src/Text/Gigaparsec/Internal/Require.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_HADDOCK hide #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 module Text.Gigaparsec.Internal.Require (require, RequirementUnsatisfied) where

--- a/src/Text/Gigaparsec/Position.hs
+++ b/src/Text/Gigaparsec/Position.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE Safe #-}
+module Text.Gigaparsec.Position (line, col, pos, offset, withWidth) where
+
+import Text.Gigaparsec.Internal (Parsec)
+import Text.Gigaparsec.Internal qualified as Internal (Parsec(Parsec), line, col, consumed)
+import Control.Applicative (liftA2, liftA3)
+
+line :: Parsec Word
+line = Internal.Parsec $ \st good _ -> good (Internal.line st) st
+
+col :: Parsec Word
+col = Internal.Parsec $ \st good _ -> good (Internal.col st) st
+
+offset :: Parsec Word
+offset = Internal.Parsec $ \st good _ -> good (Internal.consumed st) st
+
+pos :: Parsec (Word, Word)
+pos = liftA2 (,) line col
+
+withWidth :: Parsec a -> Parsec (a, Word)
+withWidth p = liftA3 (\s x e -> (x, e-s)) offset p offset

--- a/src/Text/Gigaparsec/Registers.hs
+++ b/src/Text/Gigaparsec/Registers.hs
@@ -6,9 +6,10 @@ module Text.Gigaparsec.Registers (
     put, puts,
     modify,
     local, localWith,
+    rollback
   ) where
 
-import Text.Gigaparsec (Parsec)
+import Text.Gigaparsec (Parsec, (<|>), empty)
 import Text.Gigaparsec.Internal.RT (Reg, newReg, readReg, writeReg)
 import Text.Gigaparsec.Internal qualified as Internal (Parsec(..))
 
@@ -60,5 +61,8 @@ localWith reg x = local reg (const x)
 
 _localWith :: Reg r a -> Parsec a -> Parsec b -> Parsec b
 _localWith reg px q = px >>= flip (localWith reg) q
+
+rollback :: Reg r a -> Parsec a -> Parsec a
+rollback reg p = get reg >>= \x -> p <|> (put reg x *> empty)
 
 -- TODO: for combinators

--- a/src/Text/Gigaparsec/Registers.hs
+++ b/src/Text/Gigaparsec/Registers.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE Trustworthy #-}
 module Text.Gigaparsec.Registers (
     Reg,
-    make,
+    make, unsafeMake,
     get, gets,
     put, puts,
     modify,
@@ -12,6 +12,9 @@ module Text.Gigaparsec.Registers (
 import Text.Gigaparsec (Parsec, (<|>), empty)
 import Text.Gigaparsec.Internal.RT (Reg, newReg, readReg, writeReg)
 import Text.Gigaparsec.Internal qualified as Internal (Parsec(..))
+
+unsafeMake :: (forall r. Reg r a -> Parsec b) -> Parsec b
+unsafeMake = make (error "reference used but not set")
 
 _make :: Parsec a -> (forall r. Reg r a -> Parsec b) -> Parsec b
 _make p f = p >>= \x -> make x f

--- a/src/Text/Gigaparsec/Token/Descriptions.hs
+++ b/src/Text/Gigaparsec/Token/Descriptions.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE Safe #-}
 module Text.Gigaparsec.Token.Descriptions (module Text.Gigaparsec.Token.Descriptions) where
+import Data.Char (isSpace)
 
 type LexicalDesc :: *
 data LexicalDesc = LexicalDesc { nameDesc :: !NameDesc
@@ -8,6 +9,14 @@ data LexicalDesc = LexicalDesc { nameDesc :: !NameDesc
                                , textDesc :: !TextDesc
                                , spaceDesc :: !SpaceDesc
                                }
+
+plain :: LexicalDesc
+plain = LexicalDesc { nameDesc = NameDesc {}
+                    , symbolDesc = SymbolDesc {}
+                    , numericDesc = NumericDesc {}
+                    , textDesc = TextDesc {}
+                    , spaceDesc = plainSpace
+                    }
 
 type NameDesc :: *
 data NameDesc = NameDesc {}
@@ -30,6 +39,16 @@ data SpaceDesc = SpaceDesc { commentStart :: !String
                            , space :: !CharPredicate
                            , whitespaceIsContextDependent :: !Bool
                            }
+
+plainSpace :: SpaceDesc
+plainSpace = SpaceDesc { commentStart = ""
+                       , commentEnd = ""
+                       , commentLine = ""
+                       , commentLineAllowsEOF = True
+                       , nestedComments = False
+                       , space = Just isSpace
+                       , whitespaceIsContextDependent = False
+                       }
 
 type CharPredicate :: *
 type CharPredicate = Maybe (Char -> Bool)

--- a/src/Text/Gigaparsec/Token/Descriptions.hs
+++ b/src/Text/Gigaparsec/Token/Descriptions.hs
@@ -1,16 +1,19 @@
 {-# LANGUAGE Safe #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# OPTIONS_GHC -Wno-partial-fields #-}
 module Text.Gigaparsec.Token.Descriptions (module Text.Gigaparsec.Token.Descriptions) where
 
 import Data.Char (isSpace)
 import Data.Set (Set)
+import Data.Map (Map)
+import Data.List.NonEmpty (NonEmpty)
 
 type LexicalDesc :: *
-data LexicalDesc = LexicalDesc { nameDesc :: !NameDesc
-                               , symbolDesc :: !SymbolDesc
-                               , numericDesc :: !NumericDesc
-                               , textDesc :: !TextDesc
-                               , spaceDesc :: !SpaceDesc
+data LexicalDesc = LexicalDesc { nameDesc :: {-# UNPACK #-} !NameDesc
+                               , symbolDesc :: {-# UNPACK #-} !SymbolDesc
+                               , numericDesc :: {-# UNPACK #-} !NumericDesc
+                               , textDesc :: {-# UNPACK #-} !TextDesc
+                               , spaceDesc :: {-# UNPACK #-} !SpaceDesc
                                }
 
 plain :: LexicalDesc
@@ -48,16 +51,139 @@ plainSymbol = SymbolDesc { hardKeywords = []
                          }
 
 type NumericDesc :: *
-data NumericDesc = NumericDesc {}
+data NumericDesc = NumericDesc { literalBreakChar :: !BreakCharDesc
+                               , leadingDotAllowed :: !Bool
+                               , trailingDotAllowed :: !Bool
+                               , leadingZerosAllowed :: !Bool
+                               , positiveSign :: !PlusSignPresence
+                               -- generic number
+                               , integerNumbersCanBeHexadecimal :: !Bool
+                               , integerNumbersCanBeOctal :: !Bool
+                               , integerNumbersCanBeBinary :: !Bool
+                               , realNumbersCanBeHexadecimal :: !Bool
+                               , realNumbersCanBeOctal :: !Bool
+                               , realNumbersCanBeBinary :: !Bool
+                               -- special literals
+                               , hexadecimalLeads :: !(Set Char)
+                               , octalLeads :: !(Set Char)
+                               , binaryLeads :: !(Set Char)
+                               -- exponents
+                               , decimalExponentDesc :: !ExponentDesc
+                               , hexadecimalExponentDesc :: !ExponentDesc
+                               , octalExponentDesc :: !ExponentDesc
+                               , binaryExponentDesc :: !ExponentDesc
+                               }
 
 plainNumeric :: NumericDesc
-plainNumeric = NumericDesc {}
+plainNumeric = NumericDesc { literalBreakChar = NoBreakChar
+                           , leadingDotAllowed = False
+                           , trailingDotAllowed = False
+                           , leadingZerosAllowed = True
+                           , positiveSign = PlusOptional
+                           -- generic number
+                           , integerNumbersCanBeHexadecimal = True
+                           , integerNumbersCanBeOctal = True
+                           , integerNumbersCanBeBinary = False
+                           , realNumbersCanBeHexadecimal = False
+                           , realNumbersCanBeOctal = False
+                           , realNumbersCanBeBinary = False
+                           -- special literals
+                           , hexadecimalLeads = ['x', 'X']
+                           , octalLeads = ['o', 'O']
+                           , binaryLeads = ['b', 'B']
+                           -- exponents
+                           , decimalExponentDesc = ExponentsSupported { compulsory = False
+                                                                      , chars = ['e', 'E']
+                                                                      , base = 10
+                                                                      , expSign = PlusOptional
+                                                                      }
+                           , hexadecimalExponentDesc = ExponentsSupported { compulsory = True
+                                                                          , chars = ['p', 'P']
+                                                                          , base = 2
+                                                                          , expSign = PlusOptional
+                                                                          }
+                           , octalExponentDesc = ExponentsSupported { compulsory = True
+                                                                    , chars = ['e', 'E', 'p', 'P']
+                                                                    , base = 2
+                                                                    , expSign = PlusOptional
+                                                                    }
+                           , binaryExponentDesc = ExponentsSupported { compulsory = True
+                                                                     , chars = ['e', 'E', 'p', 'P']
+                                                                     , base = 2
+                                                                     , expSign = PlusOptional
+                                                                     }
+                           }
+
+type ExponentDesc :: *
+data ExponentDesc = NoExponents
+                  | ExponentsSupported { compulsory :: !Bool
+                                       , chars :: !(Set Char)
+                                       , base :: !Int
+                                       , expSign :: !PlusSignPresence
+                                       }
+
+type BreakCharDesc :: *
+data BreakCharDesc = NoBreakChar
+                   | BreakCharSupported { breakChar :: !Char
+                                        , allowedAfterNonDecimalPrefix :: !Bool
+                                        }
+
+type PlusSignPresence :: *
+data PlusSignPresence = PlusRequired | PlusOptional | PlusIllegal
 
 type TextDesc :: *
-data TextDesc = TextDesc {}
+data TextDesc = TextDesc { escapeSequences :: {-# UNPACK #-} !EscapeDesc
+                         , characterLiteralEnd :: !Char
+                         , stringEnds :: !(Set String)
+                         , multiStringEnds :: !(Set String)
+                         , graphicCharacter :: !CharPredicate
+                         }
 
 plainText :: TextDesc
-plainText = TextDesc {}
+plainText = TextDesc { escapeSequences = plainEscape
+                     , characterLiteralEnd = '\''
+                     , stringEnds = ["\""]
+                     , multiStringEnds = []
+                     , graphicCharacter = Just (>= ' ')
+                     }
+
+type EscapeDesc :: *
+data EscapeDesc = EscapeDesc { escBegin :: !Char
+                             , literals :: !(Set Char)
+                             , singleMap :: !(Map Char Char)
+                             , multiMap :: !(Map String Char)
+                             , decimalEscape :: !NumericEscape
+                             , hexadecimalEscape :: !NumericEscape
+                             , octalEscape :: !NumericEscape
+                             , binaryEscape :: !NumericEscape
+                             , emptyEscape :: !(Maybe Char)
+                             , gapsSupported :: !Bool
+                             }
+
+plainEscape :: EscapeDesc
+plainEscape = EscapeDesc { escBegin = '\\'
+                         , literals = ['\\']
+                         , singleMap = []
+                         , multiMap = []
+                         , decimalEscape = NumericIllegal
+                         , hexadecimalEscape = NumericIllegal
+                         , octalEscape = NumericIllegal
+                         , binaryEscape = NumericIllegal
+                         , emptyEscape = Nothing
+                         , gapsSupported = False
+                         }
+
+-- TODO: haskellEscape
+
+type NumericEscape :: *
+data NumericEscape = NumericIllegal
+                   | NumericSupported { prefix :: !(Maybe Char)
+                                      , numDigits :: !NumberOfDigits
+                                      , maxValue :: !Int
+                                      }
+
+type NumberOfDigits :: *
+data NumberOfDigits = Unbounded | Exactly !(NonEmpty Word) | AtMost !Word
 
 type SpaceDesc :: *
 data SpaceDesc = SpaceDesc { commentStart :: !String

--- a/src/Text/Gigaparsec/Token/Descriptions.hs
+++ b/src/Text/Gigaparsec/Token/Descriptions.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE OverloadedLists #-}
 module Text.Gigaparsec.Token.Descriptions (module Text.Gigaparsec.Token.Descriptions) where
+
 import Data.Char (isSpace)
+import Data.Set (Set)
 
 type LexicalDesc :: *
 data LexicalDesc = LexicalDesc { nameDesc :: !NameDesc
@@ -11,24 +14,42 @@ data LexicalDesc = LexicalDesc { nameDesc :: !NameDesc
                                }
 
 plain :: LexicalDesc
-plain = LexicalDesc { nameDesc = NameDesc {}
-                    , symbolDesc = SymbolDesc {}
-                    , numericDesc = NumericDesc {}
-                    , textDesc = TextDesc {}
+plain = LexicalDesc { nameDesc = plainName
+                    , symbolDesc = plainSymbol
+                    , numericDesc = plainNumeric
+                    , textDesc = plainText
                     , spaceDesc = plainSpace
                     }
 
 type NameDesc :: *
 data NameDesc = NameDesc {}
 
+plainName :: NameDesc
+plainName = NameDesc {}
+
 type SymbolDesc :: *
-data SymbolDesc = SymbolDesc {}
+data SymbolDesc = SymbolDesc { hardKeywords :: !(Set String)
+                             , hardOperators :: !(Set String)
+                             , caseSensitive :: !Bool
+                             }
+
+plainSymbol :: SymbolDesc
+plainSymbol = SymbolDesc { hardKeywords = []
+                         , hardOperators = []
+                         , caseSensitive = True
+                         }
 
 type NumericDesc :: *
 data NumericDesc = NumericDesc {}
 
+plainNumeric :: NumericDesc
+plainNumeric = NumericDesc {}
+
 type TextDesc :: *
 data TextDesc = TextDesc {}
+
+plainText :: TextDesc
+plainText = TextDesc {}
 
 type SpaceDesc :: *
 data SpaceDesc = SpaceDesc { commentStart :: !String

--- a/src/Text/Gigaparsec/Token/Descriptions.hs
+++ b/src/Text/Gigaparsec/Token/Descriptions.hs
@@ -182,7 +182,7 @@ type NumericEscape :: *
 data NumericEscape = NumericIllegal
                    | NumericSupported { prefix :: !(Maybe Char)
                                       , numDigits :: !NumberOfDigits
-                                      , maxValue :: !Int
+                                      , maxValue :: !Char
                                       }
 
 type NumberOfDigits :: *

--- a/src/Text/Gigaparsec/Token/Descriptions.hs
+++ b/src/Text/Gigaparsec/Token/Descriptions.hs
@@ -96,21 +96,25 @@ plainNumeric = NumericDesc { literalBreakChar = NoBreakChar
                                                                       , chars = ['e', 'E']
                                                                       , base = 10
                                                                       , expSign = PlusOptional
+                                                                      , expLeadingZerosAllowd = True
                                                                       }
                            , hexadecimalExponentDesc = ExponentsSupported { compulsory = True
                                                                           , chars = ['p', 'P']
                                                                           , base = 2
                                                                           , expSign = PlusOptional
+                                                                          , expLeadingZerosAllowd = True
                                                                           }
                            , octalExponentDesc = ExponentsSupported { compulsory = True
                                                                     , chars = ['e', 'E', 'p', 'P']
                                                                     , base = 2
                                                                     , expSign = PlusOptional
+                                                                    , expLeadingZerosAllowd = True
                                                                     }
                            , binaryExponentDesc = ExponentsSupported { compulsory = True
                                                                      , chars = ['e', 'E', 'p', 'P']
                                                                      , base = 2
                                                                      , expSign = PlusOptional
+                                                                     , expLeadingZerosAllowd = True
                                                                      }
                            }
 
@@ -120,6 +124,7 @@ data ExponentDesc = NoExponents
                                        , chars :: !(Set Char)
                                        , base :: !Int
                                        , expSign :: !PlusSignPresence
+                                       , expLeadingZerosAllowd :: !Bool
                                        }
 
 type BreakCharDesc :: *
@@ -134,15 +139,15 @@ data PlusSignPresence = PlusRequired | PlusOptional | PlusIllegal
 type TextDesc :: *
 data TextDesc = TextDesc { escapeSequences :: {-# UNPACK #-} !EscapeDesc
                          , characterLiteralEnd :: !Char
-                         , stringEnds :: !(Set String)
-                         , multiStringEnds :: !(Set String)
+                         , stringEnds :: !(Set (String, String))
+                         , multiStringEnds :: !(Set (String, String))
                          , graphicCharacter :: !CharPredicate
                          }
 
 plainText :: TextDesc
 plainText = TextDesc { escapeSequences = plainEscape
                      , characterLiteralEnd = '\''
-                     , stringEnds = ["\""]
+                     , stringEnds = [("\"", "\"")]
                      , multiStringEnds = []
                      , graphicCharacter = Just (>= ' ')
                      }
@@ -150,8 +155,7 @@ plainText = TextDesc { escapeSequences = plainEscape
 type EscapeDesc :: *
 data EscapeDesc = EscapeDesc { escBegin :: !Char
                              , literals :: !(Set Char)
-                             , singleMap :: !(Map Char Char)
-                             , multiMap :: !(Map String Char)
+                             , mapping :: !(Map String Char)
                              , decimalEscape :: !NumericEscape
                              , hexadecimalEscape :: !NumericEscape
                              , octalEscape :: !NumericEscape
@@ -163,8 +167,7 @@ data EscapeDesc = EscapeDesc { escBegin :: !Char
 plainEscape :: EscapeDesc
 plainEscape = EscapeDesc { escBegin = '\\'
                          , literals = ['\\']
-                         , singleMap = []
-                         , multiMap = []
+                         , mapping = []
                          , decimalEscape = NumericIllegal
                          , hexadecimalEscape = NumericIllegal
                          , octalEscape = NumericIllegal
@@ -186,21 +189,21 @@ type NumberOfDigits :: *
 data NumberOfDigits = Unbounded | Exactly !(NonEmpty Word) | AtMost !Word
 
 type SpaceDesc :: *
-data SpaceDesc = SpaceDesc { commentStart :: !String
-                           , commentEnd :: !String
-                           , commentLine :: !String
-                           , commentLineAllowsEOF :: !Bool
-                           , nestedComments :: !Bool
+data SpaceDesc = SpaceDesc { lineCommentStart :: !String
+                           , lineCommentAllowsEOF :: !Bool
+                           , multiLineCommentStart :: !String
+                           , multiLineCommentEnd :: !String
+                           , multiLineNestedComments :: !Bool
                            , space :: !CharPredicate
                            , whitespaceIsContextDependent :: !Bool
                            }
 
 plainSpace :: SpaceDesc
-plainSpace = SpaceDesc { commentStart = ""
-                       , commentEnd = ""
-                       , commentLine = ""
-                       , commentLineAllowsEOF = True
-                       , nestedComments = False
+plainSpace = SpaceDesc { lineCommentStart = ""
+                       , lineCommentAllowsEOF = True
+                       , multiLineCommentStart = ""
+                       , multiLineCommentEnd = ""
+                       , multiLineNestedComments = False
                        , space = Just isSpace
                        , whitespaceIsContextDependent = False
                        }

--- a/src/Text/Gigaparsec/Token/Descriptions.hs
+++ b/src/Text/Gigaparsec/Token/Descriptions.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE Safe #-}
+module Text.Gigaparsec.Token.Descriptions (module Text.Gigaparsec.Token.Descriptions) where
+
+type LexicalDesc :: *
+data LexicalDesc = LexicalDesc { nameDesc :: !NameDesc
+                               , symbolDesc :: !SymbolDesc
+                               , numericDesc :: !NumericDesc
+                               , textDesc :: !TextDesc
+                               , spaceDesc :: !SpaceDesc
+                               }
+
+type NameDesc :: *
+data NameDesc = NameDesc {}
+
+type SymbolDesc :: *
+data SymbolDesc = SymbolDesc {}
+
+type NumericDesc :: *
+data NumericDesc = NumericDesc {}
+
+type TextDesc :: *
+data TextDesc = TextDesc {}
+
+type SpaceDesc :: *
+data SpaceDesc = SpaceDesc { commentStart :: !String
+                           , commentEnd :: !String
+                           , commentLine :: !String
+                           , commentLineAllowsEOF :: !Bool
+                           , nestedComments :: !Bool
+                           , space :: !CharPredicate
+                           , whitespaceIsContextDependent :: !Bool
+                           }
+
+type CharPredicate :: *
+type CharPredicate = Maybe (Char -> Bool)

--- a/src/Text/Gigaparsec/Token/Descriptions.hs
+++ b/src/Text/Gigaparsec/Token/Descriptions.hs
@@ -22,10 +22,18 @@ plain = LexicalDesc { nameDesc = plainName
                     }
 
 type NameDesc :: *
-data NameDesc = NameDesc {}
+data NameDesc = NameDesc { identifierStart :: !CharPredicate
+                         , identifierLetter :: !CharPredicate
+                         , operatorStart :: !CharPredicate
+                         , operatorLetter :: !CharPredicate
+                         }
 
 plainName :: NameDesc
-plainName = NameDesc {}
+plainName = NameDesc { identifierStart = Nothing
+                     , identifierLetter = Nothing
+                     , operatorStart = Nothing
+                     , operatorLetter = Nothing
+                     }
 
 type SymbolDesc :: *
 data SymbolDesc = SymbolDesc { hardKeywords :: !(Set String)

--- a/src/Text/Gigaparsec/Token/Generic.hs
+++ b/src/Text/Gigaparsec/Token/Generic.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE OverloadedLists, NamedFieldPuns #-}
+module Text.Gigaparsec.Token.Generic (module Text.Gigaparsec.Token.Generic) where
+
+import safe Text.Gigaparsec ((<|>), many, Parsec, ($>), (<:>))
+import Text.Gigaparsec.Char (satisfy, char, digit, hexDigit, octDigit, bit)
+import Text.Gigaparsec.Combinator (optional)
+import Text.Gigaparsec.Errors.Combinator ((<?>), hide)
+import Text.Gigaparsec.Token.Descriptions (
+    BreakCharDesc(BreakCharSupported, NoBreakChar),
+    NumericDesc(NumericDesc, literalBreakChar, leadingZerosAllowed)
+  )
+
+import Data.Char (isDigit, isHexDigit, isOctDigit, digitToInt)
+import Data.List (foldl')
+
+type GenericNumeric :: *
+data GenericNumeric = Generic { zeroAllowedDecimal :: Parsec Integer
+                              , zeroAllowedHexadecimal :: Parsec Integer
+                              , zeroAllowedOctal :: Parsec Integer
+                              , zeroAllowedBinary :: Parsec Integer
+                              , zeroNotAllowedDecimal :: Parsec Integer
+                              , zeroNotAllowedHexadecimal :: Parsec Integer
+                              , zeroNotAllowedOctal :: Parsec Integer
+                              , zeroNotAllowedBinary :: Parsec Integer
+                              , plainDecimal :: NumericDesc -> Parsec Integer
+                              , plainHexadecimal :: NumericDesc -> Parsec Integer
+                              , plainOctal :: NumericDesc -> Parsec Integer
+                              , plainBinary :: NumericDesc -> Parsec Integer
+                              }
+
+mkGeneric :: GenericNumeric
+mkGeneric = Generic {..}
+  where ofRadix1 :: Integer -> Parsec Char -> Parsec Integer
+        ofRadix1 radix dig = ofRadix2 radix dig dig
+        ofRadix2 :: Integer -> Parsec Char -> Parsec Char -> Parsec Integer
+        ofRadix2 radix startDig dig = foldl' (withDigit radix) 0 <$> (startDig <:> many dig) --TODO: improve
+
+        ofRadixBreak1 :: Integer -> Parsec Char -> Char -> Parsec Integer
+        ofRadixBreak1 radix dig = ofRadixBreak2 radix dig dig
+        ofRadixBreak2 :: Integer -> Parsec Char -> Parsec Char -> Char -> Parsec Integer
+        ofRadixBreak2 radix startDig dig breakChar =
+          foldl' (withDigit radix) 0 <$> (startDig <:> many (optional (char breakChar) *> dig)) --TODO: improve
+
+        nonZeroDigit = satisfy (\c -> isDigit c && c /= '0') <?> ["digit"]
+        nonZeroHexDigit = satisfy (\c -> isHexDigit c && c /= '0') <?> ["hexadecimal digit"]
+        nonZeroOctDigit = satisfy (\c -> isOctDigit c && c /= '0') <?> ["octal digit"]
+        nonZeroBit = char '1' <?> ["bit"]
+        -- why secret? so that the above digits can be marked as digits without "non-zero or zero digit"
+        secretZero :: Parsec Integer
+        secretZero = hide (char '0') $> 0
+
+        zeroAllowedDecimal = ofRadix1 10 digit
+        zeroAllowedHexadecimal = ofRadix1 16 hexDigit
+        zeroAllowedOctal = ofRadix1 8 octDigit
+        zeroAllowedBinary = ofRadix1 2 bit
+
+        zeroNotAllowedDecimal = ofRadix2 10 nonZeroDigit digit <|> secretZero
+        zeroNotAllowedHexadecimal = ofRadix2 16 nonZeroHexDigit hexDigit <|> secretZero
+        zeroNotAllowedOctal = ofRadix2 8 nonZeroOctDigit octDigit <|> secretZero
+        zeroNotAllowedBinary = ofRadix2 2 nonZeroBit bit <|> secretZero
+
+        plainDecimal NumericDesc{leadingZerosAllowed, literalBreakChar} = case literalBreakChar of
+          NoBreakChar | leadingZerosAllowed            -> zeroAllowedDecimal
+          NoBreakChar                                  -> zeroNotAllowedDecimal
+          BreakCharSupported c _ | leadingZerosAllowed -> ofRadixBreak1 10 digit c
+          BreakCharSupported c _                       -> ofRadixBreak2 10 nonZeroDigit digit c <|> secretZero
+
+        plainHexadecimal NumericDesc{leadingZerosAllowed, literalBreakChar} = case literalBreakChar of
+          NoBreakChar | leadingZerosAllowed            -> zeroAllowedDecimal
+          NoBreakChar                                  -> zeroNotAllowedDecimal
+          BreakCharSupported c _ | leadingZerosAllowed -> ofRadixBreak1 16 hexDigit c
+          BreakCharSupported c _                       -> ofRadixBreak2 16 nonZeroHexDigit hexDigit c <|> secretZero
+
+        plainOctal NumericDesc{leadingZerosAllowed, literalBreakChar} = case literalBreakChar of
+          NoBreakChar | leadingZerosAllowed            -> zeroAllowedDecimal
+          NoBreakChar                                  -> zeroNotAllowedDecimal
+          BreakCharSupported c _ | leadingZerosAllowed -> ofRadixBreak1 8 octDigit c
+          BreakCharSupported c _                       -> ofRadixBreak2 8 nonZeroOctDigit octDigit c <|> secretZero
+
+        plainBinary NumericDesc{leadingZerosAllowed, literalBreakChar} = case literalBreakChar of
+          NoBreakChar | leadingZerosAllowed            -> zeroAllowedDecimal
+          NoBreakChar                                  -> zeroNotAllowedDecimal
+          BreakCharSupported c _ | leadingZerosAllowed -> ofRadixBreak1 2 bit c
+          BreakCharSupported c _                       -> ofRadixBreak2 2 nonZeroBit bit c <|> secretZero
+
+withDigit :: Integer -> Integer -> Char -> Integer
+withDigit radix n d = n * radix + fromIntegral (digitToInt d)

--- a/src/Text/Gigaparsec/Token/Lexer.hs
+++ b/src/Text/Gigaparsec/Token/Lexer.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wno-partial-fields #-}
+module Text.Gigaparsec.Token.Lexer (Lexer, mkLexer, lexeme, nonlexeme) where
+
+import Text.Gigaparsec (Parsec, eof, void, empty, (<|>))
+import Text.Gigaparsec.Char (satisfy)
+import Text.Gigaparsec.Combinator (skipMany)
+import Text.Gigaparsec.Token.Descriptions
+import Control.Exception (Exception, throw)
+import Text.Gigaparsec.Registers (put, get, localWith, rollback)
+import System.IO.Unsafe (unsafePerformIO)
+import Data.IORef (newIORef)
+import Text.Gigaparsec.Internal.RT (fromIORef)
+import Control.Monad (join)
+
+type Lexer :: *
+data Lexer = Lexer { lexeme :: !Lexeme
+                   , nonlexeme :: !Lexeme
+                   , fully :: !(forall a. Parsec a -> Parsec a)
+                   , space :: !Space
+                   }
+
+mkLexer :: LexicalDesc -> Lexer
+mkLexer LexicalDesc{..} = Lexer {..}
+  where lexeme = Lexeme { apply = id
+                        }
+        nonlexeme = NonLexeme {}
+        fully' p =  whiteSpace space *> p <* eof
+        fully p
+          | whitespaceIsContextDependent spaceDesc = initSpace space *> fully' p
+          | otherwise                              = fully' p
+        space = mkSpace spaceDesc
+
+type Lexeme :: *
+data Lexeme = Lexeme
+                { apply :: !(forall a. Parsec a -> Parsec a) -- this is tricky...
+                }
+            | NonLexeme
+                {
+                }
+
+type Space :: *
+data Space = Space { whiteSpace :: !(Parsec ())
+                   , skipComments :: !(Parsec ())
+                   , alter :: forall a. CharPredicate -> Parsec a -> Parsec a
+                   , initSpace :: Parsec ()
+                   }
+
+mkSpace :: SpaceDesc -> Space
+mkSpace desc@SpaceDesc{..} = Space {..}
+  where -- don't think we can trust doing initialisation here, it'll happen in some random order
+        {-# NOINLINE wsImpl #-}
+        !wsImpl = fromIORef (unsafePerformIO (newIORef (error "uninitialised space")))
+        comment = empty @Parsec @() -- FIXME:
+        implOf
+          | supportsComments desc = maybe skipComments (skipMany . (<|> comment) . void . satisfy)
+          | otherwise             = maybe empty (skipMany . satisfy)
+        configuredWhitespace = implOf space
+        whiteSpace
+          | whitespaceIsContextDependent = join (get wsImpl)
+          | otherwise                    = configuredWhitespace
+        skipComments = skipMany comment
+        alter p
+          | whitespaceIsContextDependent = rollback wsImpl . localWith wsImpl (implOf p)
+          | otherwise                    = throw (UnsupportedOperation badAlter)
+        initSpace
+          | whitespaceIsContextDependent = put wsImpl configuredWhitespace
+          | otherwise                    = throw (UnsupportedOperation badInit)
+        badInit = "whitespace cannot be initialised unless `spaceDesc.whitespaceIsContextDependent` is True"
+        badAlter = "whitespace cannot be altered unless `spaceDesc.whitespaceIsContextDependent` is True"
+
+supportsComments :: SpaceDesc -> Bool
+supportsComments SpaceDesc{..} = not (null commentLine && null commentStart)
+
+type UnsupportedOperation :: *
+newtype UnsupportedOperation = UnsupportedOperation String deriving stock Eq
+instance Show UnsupportedOperation where
+  show (UnsupportedOperation msg) = "unsupported operation: " ++ msg
+instance Exception UnsupportedOperation

--- a/src/Text/Gigaparsec/Token/Lexer.hs
+++ b/src/Text/Gigaparsec/Token/Lexer.hs
@@ -1,11 +1,17 @@
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-partial-fields #-}
+-- Ideally, we should probably expose all the functionally via this one file
+-- for ergonomics
 module Text.Gigaparsec.Token.Lexer (
     Lexer, mkLexer,
     lexeme, nonlexeme, fully, space,
     skipComments, whiteSpace, alter, initSpace,
-    sym, symbol,
+    sym, symbol, names,
+    -- Symbol
+    softKeyword, softOperator,
+    -- Names
+    identifier, identifier', userDefinedOperator, userDefinedOperator',
     apply
   ) where
 
@@ -16,9 +22,11 @@ import Text.Gigaparsec.Registers (put, get, localWith, rollback)
 import Text.Gigaparsec.Errors.Combinator (hide)
 
 import Text.Gigaparsec.Token.Descriptions qualified as Desc
-import Text.Gigaparsec.Token.Symbol (Symbol, mkSym, mkSymbol)
+import Text.Gigaparsec.Token.Symbol (Symbol, mkSym, mkSymbol, softKeyword, softOperator)
 import Text.Gigaparsec.Token.Symbol qualified as Symbol (lexeme)
-import Text.Gigaparsec.Token.Names (Names, mkNames)
+import Text.Gigaparsec.Token.Names (
+    Names, mkNames, identifier, identifier', userDefinedOperator, userDefinedOperator'
+  )
 import Text.Gigaparsec.Token.Names qualified as Names (lexeme)
 
 import Text.Gigaparsec.Internal.RT (fromIORef)

--- a/src/Text/Gigaparsec/Token/Lexer.hs
+++ b/src/Text/Gigaparsec/Token/Lexer.hs
@@ -11,6 +11,7 @@ module Text.Gigaparsec.Token.Lexer (
     -- Names
     identifier, identifier', userDefinedOperator, userDefinedOperator',
     -- Numeric
+    integer, natural,
     -- Text
     -- Space
     skipComments, whiteSpace, alter, initSpace,

--- a/src/Text/Gigaparsec/Token/Lexer.hs
+++ b/src/Text/Gigaparsec/Token/Lexer.hs
@@ -32,10 +32,11 @@ import Text.Gigaparsec.Token.Names (
 import Text.Gigaparsec.Token.Names qualified as Names (lexeme)
 import Text.Gigaparsec.Token.Numeric (
     IntegerParsers, mkSigned, mkUnsigned,
-    FloatingParsers, mkSignedFloating, mkUnsignedFloating,
-    CombinedParsers, mkSignedCombined, mkUnsignedCombined, CanHoldSigned, CanHoldUnsigned
+    --FloatingParsers, mkSignedFloating, mkUnsignedFloating,
+    --CombinedParsers, mkSignedCombined, mkUnsignedCombined,
+    CanHoldSigned, CanHoldUnsigned
   )
-import Text.Gigaparsec.Token.Numeric qualified as Numeric (lexemeInteger, lexemeFloating, lexemeCombined)
+import Text.Gigaparsec.Token.Numeric qualified as Numeric (lexemeInteger, {-lexemeFloating, lexemeCombined-})
 
 import Text.Gigaparsec.Internal.RT (fromIORef)
 import Text.Gigaparsec.Internal.Require (require)
@@ -63,22 +64,22 @@ mkLexer Desc.LexicalDesc{..} = Lexer {..}
                         , names = Names.lexeme apply (names nonlexeme)
                         , natural = Numeric.lexemeInteger apply (natural nonlexeme)
                         , integer = Numeric.lexemeInteger apply (integer nonlexeme)
-                        , floating = Numeric.lexemeFloating apply (floating nonlexeme)
+                        {-, floating = Numeric.lexemeFloating apply (floating nonlexeme)
                         , unsignedCombined =
                             Numeric.lexemeCombined apply (unsignedCombined nonlexeme)
                         , signedCombined =
-                            Numeric.lexemeCombined apply (signedCombined nonlexeme)
+                            Numeric.lexemeCombined apply (signedCombined nonlexeme)-}
                         }
         nonlexeme = NonLexeme { sym = mkSym symbolDesc (symbol nonlexeme)
                               , symbol = mkSymbol symbolDesc nameDesc
                               , names = mkNames nameDesc symbolDesc
                               , natural = mkUnsigned numericDesc gen
                               , integer = mkSigned numericDesc (natural nonlexeme)
-                              , floating = mkSignedFloating numericDesc positiveFloating
+                              {-, floating = mkSignedFloating numericDesc positiveFloating
                               , unsignedCombined = mkUnsignedCombined numericDesc (natural nonlexeme) positiveFloating
-                              , signedCombined = mkSignedCombined numericDesc (unsignedCombined nonlexeme)
+                              , signedCombined = mkSignedCombined numericDesc (unsignedCombined nonlexeme)-}
                               }
-        positiveFloating = mkUnsignedFloating numericDesc (natural nonlexeme) gen
+        --positiveFloating = mkUnsignedFloating numericDesc (natural nonlexeme) gen
         fully' p = whiteSpace space *> p <* eof
         fully p
           | Desc.whitespaceIsContextDependent spaceDesc = initSpace space *> fully' p
@@ -94,9 +95,10 @@ data Lexeme = Lexeme
                 , names :: !Names
                 , natural :: !(IntegerParsers CanHoldUnsigned)
                 , integer :: !(IntegerParsers CanHoldSigned)
-                , floating :: !FloatingParsers
-                , unsignedCombined :: !CombinedParsers
-                , signedCombined :: !CombinedParsers
+                -- desperate times, desperate measures
+                --, floating :: !FloatingParsers
+                --, unsignedCombined :: !CombinedParsers
+                --, signedCombined :: !CombinedParsers
                 }
             | NonLexeme
                 { sym :: !(String -> Parsec ())
@@ -104,9 +106,10 @@ data Lexeme = Lexeme
                 , names :: !Names
                 , natural :: !(IntegerParsers CanHoldUnsigned)
                 , integer :: !(IntegerParsers CanHoldSigned)
-                , floating :: !FloatingParsers
-                , unsignedCombined :: !CombinedParsers
-                , signedCombined :: !CombinedParsers
+                -- desperate times, desperate measures
+                --, floating :: !FloatingParsers
+                --, unsignedCombined :: !CombinedParsers
+                --, signedCombined :: !CombinedParsers
                 }
 
 type Space :: *

--- a/src/Text/Gigaparsec/Token/Lexer.hs
+++ b/src/Text/Gigaparsec/Token/Lexer.hs
@@ -33,7 +33,7 @@ import Text.Gigaparsec.Token.Names qualified as Names (lexeme)
 import Text.Gigaparsec.Token.Numeric (
     IntegerParsers, mkSigned, mkUnsigned,
     FloatingParsers, mkSignedFloating, mkUnsignedFloating,
-    CombinedParsers, mkSignedCombined, mkUnsignedCombined
+    CombinedParsers, mkSignedCombined, mkUnsignedCombined, CanHoldSigned, CanHoldUnsigned
   )
 import Text.Gigaparsec.Token.Numeric qualified as Numeric (lexemeInteger, lexemeFloating, lexemeCombined)
 
@@ -92,8 +92,8 @@ data Lexeme = Lexeme
                 , sym :: !(String -> Parsec ())
                 , symbol :: !Symbol
                 , names :: !Names
-                , natural :: !IntegerParsers
-                , integer :: !IntegerParsers
+                , natural :: !(IntegerParsers CanHoldUnsigned)
+                , integer :: !(IntegerParsers CanHoldSigned)
                 , floating :: !FloatingParsers
                 , unsignedCombined :: !CombinedParsers
                 , signedCombined :: !CombinedParsers
@@ -102,8 +102,8 @@ data Lexeme = Lexeme
                 { sym :: !(String -> Parsec ())
                 , symbol :: !Symbol
                 , names :: !Names
-                , natural :: !IntegerParsers
-                , integer :: !IntegerParsers
+                , natural :: !(IntegerParsers CanHoldUnsigned)
+                , integer :: !(IntegerParsers CanHoldSigned)
                 , floating :: !FloatingParsers
                 , unsignedCombined :: !CombinedParsers
                 , signedCombined :: !CombinedParsers

--- a/src/Text/Gigaparsec/Token/Lexer.hs
+++ b/src/Text/Gigaparsec/Token/Lexer.hs
@@ -18,6 +18,8 @@ import Text.Gigaparsec.Errors.Combinator (hide)
 import Text.Gigaparsec.Token.Descriptions qualified as Desc
 import Text.Gigaparsec.Token.Symbol (Symbol, mkSym, mkSymbol)
 import Text.Gigaparsec.Token.Symbol qualified as Symbol (lexeme)
+import Text.Gigaparsec.Token.Names (Names, mkNames)
+import Text.Gigaparsec.Token.Names qualified as Names (lexeme)
 
 import Text.Gigaparsec.Internal.RT (fromIORef)
 import Text.Gigaparsec.Internal.Require (require)
@@ -41,9 +43,11 @@ mkLexer Desc.LexicalDesc{..} = Lexer {..}
         lexeme = Lexeme { apply = apply
                         , sym = apply . sym nonlexeme
                         , symbol = Symbol.lexeme apply (symbol nonlexeme)
+                        , names = Names.lexeme apply (names nonlexeme)
                         }
         nonlexeme = NonLexeme { sym = mkSym symbolDesc (symbol nonlexeme)
                               , symbol = mkSymbol symbolDesc nameDesc
+                              , names = mkNames nameDesc symbolDesc
                               }
         fully' p = whiteSpace space *> p <* eof
         fully p
@@ -57,10 +61,12 @@ data Lexeme = Lexeme
                 { apply :: !(forall a. Parsec a -> Parsec a) -- this is tricky...
                 , sym :: !(String -> Parsec ())
                 , symbol :: !Symbol
+                , names :: !Names
                 }
             | NonLexeme
                 { sym :: !(String -> Parsec ())
                 , symbol :: !Symbol
+                , names :: !Names
                 }
 
 type Space :: *

--- a/src/Text/Gigaparsec/Token/Lexer.hs
+++ b/src/Text/Gigaparsec/Token/Lexer.hs
@@ -1,18 +1,25 @@
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-partial-fields #-}
-module Text.Gigaparsec.Token.Lexer (Lexer, mkLexer, lexeme, nonlexeme) where
+module Text.Gigaparsec.Token.Lexer (
+    Lexer, mkLexer,
+    lexeme, nonlexeme, fully, space,
+    skipComments, whiteSpace, alter, initSpace,
+    apply
+  ) where
 
-import Text.Gigaparsec (Parsec, eof, void, empty, (<|>))
-import Text.Gigaparsec.Char (satisfy)
-import Text.Gigaparsec.Combinator (skipMany)
-import Text.Gigaparsec.Token.Descriptions
+import Text.Gigaparsec (Parsec, eof, void, empty, (<|>), atomic, unit)
+import Text.Gigaparsec.Char (satisfy, string, item, endOfLine)
+import Text.Gigaparsec.Combinator (skipMany, manyTill)
+import Text.Gigaparsec.Token.Descriptions qualified as Desc
 import Control.Exception (Exception, throw)
 import Text.Gigaparsec.Registers (put, get, localWith, rollback)
 import System.IO.Unsafe (unsafePerformIO)
 import Data.IORef (newIORef)
 import Text.Gigaparsec.Internal.RT (fromIORef)
-import Control.Monad (join)
+import Control.Monad (join, guard)
+import Text.Gigaparsec.Internal.Require (require)
+import Data.List (isPrefixOf)
 
 type Lexer :: *
 data Lexer = Lexer { lexeme :: !Lexeme
@@ -21,15 +28,15 @@ data Lexer = Lexer { lexeme :: !Lexeme
                    , space :: !Space
                    }
 
-mkLexer :: LexicalDesc -> Lexer
-mkLexer LexicalDesc{..} = Lexer {..}
+mkLexer :: Desc.LexicalDesc -> Lexer
+mkLexer Desc.LexicalDesc{..} = Lexer {..}
   where lexeme = Lexeme { apply = id
                         }
         nonlexeme = NonLexeme {}
         fully' p =  whiteSpace space *> p <* eof
         fully p
-          | whitespaceIsContextDependent spaceDesc = initSpace space *> fully' p
-          | otherwise                              = fully' p
+          | Desc.whitespaceIsContextDependent spaceDesc = initSpace space *> fully' p
+          | otherwise                                   = fully' p
         space = mkSpace spaceDesc
 
 type Lexeme :: *
@@ -43,24 +50,24 @@ data Lexeme = Lexeme
 type Space :: *
 data Space = Space { whiteSpace :: !(Parsec ())
                    , skipComments :: !(Parsec ())
-                   , alter :: forall a. CharPredicate -> Parsec a -> Parsec a
+                   , alter :: forall a. Desc.CharPredicate -> Parsec a -> Parsec a
                    , initSpace :: Parsec ()
                    }
 
-mkSpace :: SpaceDesc -> Space
-mkSpace desc@SpaceDesc{..} = Space {..}
+mkSpace :: Desc.SpaceDesc -> Space
+mkSpace desc@Desc.SpaceDesc{..} = Space {..}
   where -- don't think we can trust doing initialisation here, it'll happen in some random order
         {-# NOINLINE wsImpl #-}
         !wsImpl = fromIORef (unsafePerformIO (newIORef (error "uninitialised space")))
-        comment = empty @Parsec @() -- FIXME:
+        comment = commentParser desc -- do not make this lazy
         implOf
           | supportsComments desc = maybe skipComments (skipMany . (<|> comment) . void . satisfy)
           | otherwise             = maybe empty (skipMany . satisfy)
-        configuredWhitespace = implOf space
-        whiteSpace
+        !configuredWhitespace = implOf space
+        !whiteSpace
           | whitespaceIsContextDependent = join (get wsImpl)
           | otherwise                    = configuredWhitespace
-        skipComments = skipMany comment
+        !skipComments = skipMany comment
         alter p
           | whitespaceIsContextDependent = rollback wsImpl . localWith wsImpl (implOf p)
           | otherwise                    = throw (UnsupportedOperation badAlter)
@@ -70,8 +77,43 @@ mkSpace desc@SpaceDesc{..} = Space {..}
         badInit = "whitespace cannot be initialised unless `spaceDesc.whitespaceIsContextDependent` is True"
         badAlter = "whitespace cannot be altered unless `spaceDesc.whitespaceIsContextDependent` is True"
 
-supportsComments :: SpaceDesc -> Bool
-supportsComments SpaceDesc{..} = not (null commentLine && null commentStart)
+{-
+We have the following invariances to be checked up front:
+  * at least one kind of comment must be enabled
+  * the starts of line and multiline must not overlap
+
+-- TODO: needs error messages put in
+-- TODO: optimise manyTill?
+-- TODO: remove guard, configure properly
+-}
+commentParser :: Desc.SpaceDesc -> Parsec ()
+commentParser Desc.SpaceDesc{..} =
+  require (multiEnabled || singleEnabled) "skipComments" noComments $
+    require (not (multiEnabled && isPrefixOf commentStart commentLine)) "skipComments" noOverlap $
+      void (multiLine <|> singleLine)
+  where
+    -- can't make these string until guard is gone
+    openComment = atomic (string commentStart)
+    closeComment = atomic (string commentEnd)
+    multiLine = guard multiEnabled *> openComment *> wellNested 1
+    wellNested :: Int -> Parsec ()
+    wellNested 0 = unit
+    wellNested n = closeComment *> wellNested (n - 1)
+               <|> guard nestedComments *> openComment *> wellNested (n + 1)
+               <|> item *> wellNested n -- TODO: can this loop be tightened? first characters?
+    singleLine = guard singleEnabled
+              *> atomic (string commentLine)
+              *> void (manyTill item endOfLineComment)
+
+    endOfLineComment = if commentLineAllowsEOF then void endOfLine <|> eof else void endOfLine
+
+    multiEnabled = not (null commentStart || null commentEnd)
+    singleEnabled = not (null commentLine)
+    noComments = "one of single- or multi-line comments must be enabled"
+    noOverlap = "single-line comments must not overlap with multi-line comments"
+
+supportsComments :: Desc.SpaceDesc -> Bool
+supportsComments Desc.SpaceDesc{..} = not (null commentLine && null commentStart)
 
 type UnsupportedOperation :: *
 newtype UnsupportedOperation = UnsupportedOperation String deriving stock Eq

--- a/src/Text/Gigaparsec/Token/Names.hs
+++ b/src/Text/Gigaparsec/Token/Names.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE RecordWildCards, OverloadedLists #-}
+module Text.Gigaparsec.Token.Names where
+
+import Text.Gigaparsec (Parsec, empty, (<:>), atomic, filterS)
+import Text.Gigaparsec.Char (stringOfMany, satisfy)
+import Text.Gigaparsec.Errors.Combinator ((<?>))
+
+import Data.Set qualified as Set (member)
+
+import Text.Gigaparsec.Token.Descriptions
+
+-- TODO: primes are gross, better way?
+type Names :: *
+data Names = Names { identifier :: !(Parsec String)
+                   , identifier' :: !(CharPredicate -> Parsec String)
+                   , userDefinedOperator :: !(Parsec String)
+                   , userDefinedOperator' :: !(CharPredicate -> Parsec String)
+                   }
+
+mkNames :: NameDesc -> SymbolDesc -> Names
+mkNames NameDesc{..} SymbolDesc{..} = Names {..}
+  where
+    -- TODO: error transformers
+    identifier =
+      keyOrOp identifierStart identifierLetter (flip Set.member hardKeywords) "identifier" id
+    identifier' start =
+      filterS (startsWith start) identifier
+    userDefinedOperator =
+      keyOrOp operatorStart operatorLetter (flip Set.member hardOperators) "operator" id
+    userDefinedOperator' start =
+      filterS (startsWith start) identifier
+
+    keyOrOp :: CharPredicate -> CharPredicate -> (String -> Bool) -> String -> (String -> String) -> Parsec String
+    keyOrOp start letter illegal name _unexpectedIllegal = --FIXME: errors!
+      atomic (filterS (not . illegal) (complete start letter)) <?> [name]
+
+    trailer :: CharPredicate -> Parsec String
+    trailer = maybe (pure "") stringOfMany
+
+    complete :: CharPredicate -> CharPredicate -> Parsec String
+    complete (Just start) letter = satisfy start <:> trailer letter
+    complete Nothing _ = empty
+
+    startsWith :: CharPredicate -> String -> Bool
+    startsWith Nothing _ = True
+    startsWith (Just _) [] = False
+    startsWith (Just p) (c:_) = p c
+
+lexeme :: (forall a. Parsec a -> Parsec a) -> Names -> Names
+lexeme = const id

--- a/src/Text/Gigaparsec/Token/Names.hs
+++ b/src/Text/Gigaparsec/Token/Names.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE RecordWildCards, OverloadedLists #-}
+{-# LANGUAGE OverloadedLists #-}
 module Text.Gigaparsec.Token.Names (
     Names, mkNames,
     identifier, identifier',

--- a/src/Text/Gigaparsec/Token/Names.hs
+++ b/src/Text/Gigaparsec/Token/Names.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE Safe #-}
 {-# LANGUAGE RecordWildCards, OverloadedLists #-}
-module Text.Gigaparsec.Token.Names where
+module Text.Gigaparsec.Token.Names (
+    Names, mkNames,
+    identifier, identifier',
+    userDefinedOperator, userDefinedOperator',
+    lexeme
+  ) where
 
 import Text.Gigaparsec (Parsec, empty, (<:>), atomic, filterS)
 import Text.Gigaparsec.Char (stringOfMany, satisfy)
@@ -8,7 +13,12 @@ import Text.Gigaparsec.Errors.Combinator ((<?>))
 
 import Data.Set qualified as Set (member)
 
-import Text.Gigaparsec.Token.Descriptions
+import Text.Gigaparsec.Token.Descriptions (
+    SymbolDesc(SymbolDesc, hardKeywords, hardOperators),
+    NameDesc(NameDesc, identifierStart, identifierLetter,
+                       operatorStart, operatorLetter),
+    CharPredicate
+  )
 
 -- TODO: primes are gross, better way?
 type Names :: *
@@ -48,4 +58,8 @@ mkNames NameDesc{..} SymbolDesc{..} = Names {..}
     startsWith (Just p) (c:_) = p c
 
 lexeme :: (forall a. Parsec a -> Parsec a) -> Names -> Names
-lexeme = const id
+lexeme lexe Names{..} = Names { identifier = lexe identifier
+                              , identifier' = lexe . identifier'
+                              , userDefinedOperator = lexe userDefinedOperator
+                              , userDefinedOperator' = lexe . userDefinedOperator'
+                              }

--- a/src/Text/Gigaparsec/Token/Numeric.hs
+++ b/src/Text/Gigaparsec/Token/Numeric.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE Safe #-}
 {-# LANGUAGE DataKinds, KindSignatures, ConstraintKinds, MultiParamTypeClasses, AllowAmbiguousTypes, FlexibleInstances, FlexibleContexts, UndecidableInstances, ApplicativeDo #-}
--- TODO: refine
+-- TODO: refine, move to Internal
 module Text.Gigaparsec.Token.Numeric (module Text.Gigaparsec.Token.Numeric) where
 
 import Text.Gigaparsec (Parsec, mapMaybeS, unit, void, atomic, (<|>), ($>))

--- a/src/Text/Gigaparsec/Token/Numeric.hs
+++ b/src/Text/Gigaparsec/Token/Numeric.hs
@@ -1,24 +1,274 @@
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE DataKinds, KindSignatures, MultiParamTypeClasses, AllowAmbiguousTypes, FlexibleInstances, FlexibleContexts, UndecidableInstances, ApplicativeDo #-}
 -- TODO: refine
 module Text.Gigaparsec.Token.Numeric (module Text.Gigaparsec.Token.Numeric) where
 
-import Text.Gigaparsec (Parsec)
+import Text.Gigaparsec (Parsec, mapMaybeS, unit, void, atomic, (<|>), ($>))
+import Text.Gigaparsec.Char (char, oneOf)
+import Text.Gigaparsec.Combinator (optional, optionalAs)
 import Text.Gigaparsec.Token.Descriptions
-import Text.Gigaparsec.Token.Generic (GenericNumeric)
+    ( BreakCharDesc(BreakCharSupported, NoBreakChar),
+      NumericDesc( NumericDesc, positiveSign, literalBreakChar
+                 , integerNumbersCanBeHexadecimal, integerNumbersCanBeOctal
+                 , integerNumbersCanBeBinary
+                 , hexadecimalLeads, octalLeads, binaryLeads
+                 ),
+      PlusSignPresence(PlusIllegal, PlusRequired, PlusOptional) )
+import Text.Gigaparsec.Token.Generic (GenericNumeric(plainDecimal, plainHexadecimal, plainOctal, plainBinary))
+import Data.Kind (Constraint)
+import Data.Int (Int8, Int16, Int32, Int64)
+import Data.Word (Word8, Word16, Word32, Word64)
+import Numeric.Natural (Natural)
+import Data.Proxy (Proxy(Proxy))
+import Control.Monad (when, unless)
 
-type IntegerParsers :: *
-data IntegerParsers = IntegerParsers {}
+type Bits :: *
+data Bits = B8 | B16 | B32 | B64
 
-mkUnsigned :: NumericDesc -> GenericNumeric -> IntegerParsers
-mkUnsigned NumericDesc{..} gen = IntegerParsers {}
+type BitBounds :: Bits -> Constraint
+class BitBounds b where
+  upperSigned :: Integer
+  lowerSigned :: Integer
+  upperUnsigned :: Integer
+  bits :: Int
+instance BitBounds 'B8 where
+  upperSigned = fromIntegral (maxBound @Int8)
+  lowerSigned = fromIntegral (minBound @Int8)
+  upperUnsigned = fromIntegral (maxBound @Word8)
+  bits = 8
+instance BitBounds 'B16 where
+  upperSigned = fromIntegral (maxBound @Int16)
+  lowerSigned = fromIntegral (minBound @Int16)
+  upperUnsigned = fromIntegral (maxBound @Word16)
+  bits = 16
+instance BitBounds 'B32 where
+  upperSigned = fromIntegral (maxBound @Int32)
+  lowerSigned = fromIntegral (minBound @Int32)
+  upperUnsigned = fromIntegral (maxBound @Word32)
+  bits = 32
+instance BitBounds 'B64 where
+  upperSigned = fromIntegral (maxBound @Int64)
+  lowerSigned = fromIntegral (minBound @Int64)
+  upperUnsigned = fromIntegral (maxBound @Word64)
+  bits = 64
 
-mkSigned :: NumericDesc -> IntegerParsers -> IntegerParsers
-mkSigned NumericDesc{..} unsigned = IntegerParsers {}
+type CanHoldSigned :: Bits -> * -> Constraint
+class (BitBounds b, Num a) => CanHoldSigned b a where
+instance CanHoldSigned 'B8 Int8
+instance CanHoldSigned 'B8 Int16
+instance CanHoldSigned 'B8 Int32
+instance CanHoldSigned 'B8 Int64
+instance CanHoldSigned 'B8 Int
+instance CanHoldSigned 'B8 Integer
+instance CanHoldSigned 'B16 Int16
+instance CanHoldSigned 'B16 Int32
+instance CanHoldSigned 'B16 Int64
+instance CanHoldSigned 'B16 Int
+instance CanHoldSigned 'B16 Integer
+instance CanHoldSigned 'B32 Int32
+instance CanHoldSigned 'B32 Int64
+instance CanHoldSigned 'B32 Int
+instance CanHoldSigned 'B32 Integer
+instance CanHoldSigned 'B64 Int64
+instance CanHoldSigned 'B64 Int
+instance CanHoldSigned 'B64 Integer
+
+type CanHoldUnsigned :: Bits -> * -> Constraint
+class (BitBounds b, Num a) => CanHoldUnsigned b a where
+instance CanHoldUnsigned 'B8 Word8
+instance CanHoldUnsigned 'B8 Word16
+instance CanHoldUnsigned 'B8 Word32
+instance CanHoldUnsigned 'B8 Word64
+instance CanHoldUnsigned 'B8 Word
+instance CanHoldUnsigned 'B8 Integer
+instance CanHoldUnsigned 'B8 Natural
+instance CanHoldUnsigned 'B16 Word16
+instance CanHoldUnsigned 'B16 Word32
+instance CanHoldUnsigned 'B16 Word64
+instance CanHoldUnsigned 'B16 Word
+instance CanHoldUnsigned 'B16 Integer
+instance CanHoldUnsigned 'B16 Natural
+instance CanHoldUnsigned 'B32 Word32
+instance CanHoldUnsigned 'B32 Word64
+instance CanHoldUnsigned 'B32 Word
+instance CanHoldUnsigned 'B32 Integer
+instance CanHoldUnsigned 'B32 Natural
+instance CanHoldUnsigned 'B64 Word64
+instance CanHoldUnsigned 'B64 Word
+instance CanHoldUnsigned 'B64 Integer
+instance CanHoldUnsigned 'B64 Natural
+
+type IntegerParsers :: (Bits -> * -> Constraint) -> *
+data IntegerParsers canHold = IntegerParsers { decimal :: Parsec Integer
+                                             , hexadecimal :: Parsec Integer
+                                             , octal :: Parsec Integer
+                                             , binary :: Parsec Integer
+                                             , number :: Parsec Integer
+                                             , decimal8 :: forall a. canHold 'B8 a => Parsec a
+                                             , hexadecimal8 :: forall a. canHold 'B8 a => Parsec a
+                                             , octal8 :: forall a. canHold 'B8 a => Parsec a
+                                             , binary8 :: forall a. canHold 'B8 a => Parsec a
+                                             , number8 :: forall a. canHold 'B8 a => Parsec a
+                                             , decimal16 :: forall a. canHold 'B16 a => Parsec a
+                                             , hexadecimal16 :: forall a. canHold 'B16 a => Parsec a
+                                             , octal16 :: forall a. canHold 'B16 a => Parsec a
+                                             , binary16 :: forall a. canHold 'B16 a => Parsec a
+                                             , number16 :: forall a. canHold 'B16 a => Parsec a
+                                             , decimal32 :: forall a. canHold 'B32 a => Parsec a
+                                             , hexadecimal32 :: forall a. canHold 'B32 a => Parsec a
+                                             , octal32 :: forall a. canHold 'B32 a => Parsec a
+                                             , binary32 :: forall a. canHold 'B32 a => Parsec a
+                                             , number32 :: forall a. canHold 'B32 a => Parsec a
+                                             , decimal64 :: forall a. canHold 'B64 a => Parsec a
+                                             , hexadecimal64 :: forall a. canHold 'B64 a => Parsec a
+                                             , octal64 :: forall a. canHold 'B64 a => Parsec a
+                                             , binary64 :: forall a. canHold 'B64 a => Parsec a
+                                             , number64 :: forall a. canHold 'B64 a => Parsec a
+                                             }
+
+mkIntegerParsers :: forall (canHold :: (Bits -> * -> Constraint)).
+                    (forall (bits :: Bits) t. canHold bits t => Proxy bits -> Parsec Integer -> Int -> Parsec t)
+                 -> Parsec Integer
+                 -> Parsec Integer
+                 -> Parsec Integer
+                 -> Parsec Integer
+                 -> Parsec Integer
+                 -> IntegerParsers canHold
+mkIntegerParsers bounded decimal hexadecimal octal binary number = IntegerParsers {..}
+  where decimalBounded :: forall (bits :: Bits) t. canHold bits t => Parsec t
+        decimalBounded = bounded (Proxy @bits) decimal 10
+
+        hexadecimalBounded :: forall (bits :: Bits) t. canHold bits t => Parsec t
+        hexadecimalBounded = bounded (Proxy @bits) hexadecimal 16
+
+        octalBounded :: forall (bits :: Bits) t. canHold bits t => Parsec t
+        octalBounded = bounded (Proxy @bits) octal 8
+
+        binaryBounded :: forall (bits :: Bits) t. canHold bits t => Parsec t
+        binaryBounded = bounded (Proxy @bits) binary 2
+
+        numberBounded :: forall (bits :: Bits) t. canHold bits t => Parsec t
+        numberBounded = bounded (Proxy @bits) number 10
+
+        decimal8 :: forall t. canHold 'B8 t => Parsec t
+        decimal8 = decimalBounded @'B8
+        decimal16 :: forall t. canHold 'B16 t => Parsec t
+        decimal16 = decimalBounded @'B16
+        decimal32 :: forall t. canHold 'B32 t => Parsec t
+        decimal32 = decimalBounded @'B32
+        decimal64 :: forall t. canHold 'B64 t => Parsec t
+        decimal64 = decimalBounded @'B64
+
+        hexadecimal8 :: forall t. canHold 'B8 t => Parsec t
+        hexadecimal8 = hexadecimalBounded @'B8
+        hexadecimal16 :: forall t. canHold 'B16 t => Parsec t
+        hexadecimal16 = hexadecimalBounded @'B16
+        hexadecimal32 :: forall t. canHold 'B32 t => Parsec t
+        hexadecimal32 = hexadecimalBounded @'B32
+        hexadecimal64 :: forall t. canHold 'B64 t => Parsec t
+        hexadecimal64 = hexadecimalBounded @'B64
+
+        octal8 :: forall t. canHold 'B8 t => Parsec t
+        octal8 = octalBounded @'B8
+        octal16 :: forall t. canHold 'B16 t => Parsec t
+        octal16 = octalBounded @'B16
+        octal32 :: forall t. canHold 'B32 t => Parsec t
+        octal32 = octalBounded @'B32
+        octal64 :: forall t. canHold 'B64 t => Parsec t
+        octal64 = octalBounded @'B64
+
+        binary8 :: forall t. canHold 'B8 t => Parsec t
+        binary8 = binaryBounded @'B8
+        binary16 :: forall t. canHold 'B16 t => Parsec t
+        binary16 = binaryBounded @'B16
+        binary32 :: forall t. canHold 'B32 t => Parsec t
+        binary32 = binaryBounded @'B32
+        binary64 :: forall t. canHold 'B64 t => Parsec t
+        binary64 = binaryBounded @'B64
+
+        number8 :: forall t. canHold 'B8 t => Parsec t
+        number8 = numberBounded @'B8
+        number16 :: forall t. canHold 'B16 t => Parsec t
+        number16 = numberBounded @'B16
+        number32 :: forall t. canHold 'B32 t => Parsec t
+        number32 = numberBounded @'B32
+        number64 :: forall t. canHold 'B64 t => Parsec t
+        number64 = numberBounded @'B64
+
+mkUnsigned :: NumericDesc -> GenericNumeric -> IntegerParsers CanHoldUnsigned
+mkUnsigned desc@NumericDesc{..} gen = mkIntegerParsers bounded decimal hexadecimal octal binary number
+  where bounded :: forall (bits :: Bits) t. CanHoldUnsigned bits t
+                => Proxy bits -> Parsec Integer -> Int -> Parsec t
+        bounded _ num _radix = mapMaybeS
+          (\n -> if n >= 0 && n <= upperUnsigned @bits then Just (fromInteger n) else Nothing)
+          num
+
+        leadingBreakChar = case literalBreakChar of
+          NoBreakChar -> unit
+          BreakCharSupported breakChar allowedAfterNonDecimalPrefix ->
+            when allowedAfterNonDecimalPrefix (optional (char breakChar))
+
+        noZeroHexadecimal = do
+          unless (null hexadecimalLeads) (void (oneOf hexadecimalLeads))
+          leadingBreakChar
+          plainHexadecimal gen desc
+
+        noZeroOctal = do
+          unless (null octalLeads) (void (oneOf octalLeads))
+          leadingBreakChar
+          plainOctal gen desc
+
+        noZeroBinary = do
+          unless (null binaryLeads) (void (oneOf binaryLeads))
+          leadingBreakChar
+          plainBinary gen desc
+
+        decimal = plainDecimal gen desc
+        hexadecimal = atomic (char '0' *> noZeroHexadecimal)
+        octal = atomic (char '0' *> noZeroOctal)
+        binary = atomic (char '0' *> noZeroBinary)
+        number
+          | not integerNumbersCanBeBinary
+          , not integerNumbersCanBeHexadecimal
+          , not integerNumbersCanBeOctal = decimal
+          | otherwise = atomic (zeroLead <|> decimal)
+          where zeroLead = char '0' *> addHex (addOct (addBin (decimal <|> pure 0)))
+                addHex
+                  | integerNumbersCanBeHexadecimal = (noZeroHexadecimal <|>)
+                  | otherwise = id
+                addOct
+                  | integerNumbersCanBeOctal = (noZeroOctal <|>)
+                  | otherwise = id
+                addBin
+                  | integerNumbersCanBeBinary = (noZeroBinary <|>)
+                  | otherwise = id
+
+mkSigned :: NumericDesc -> IntegerParsers c -> IntegerParsers CanHoldSigned
+mkSigned NumericDesc{..} unsigned =
+  mkIntegerParsers bounded _decimal _hexadecimal _octal _binary _number
+  where bounded :: forall (bits :: Bits) t. CanHoldSigned bits t
+                => Proxy bits -> Parsec Integer -> Int -> Parsec t
+        bounded _ num _radix = mapMaybeS
+          (\n -> if n >= lowerSigned @bits && n <= upperSigned @bits
+                 then Just (fromInteger n)
+                 else Nothing)
+          num
+
+        sign :: Parsec (Integer -> Integer)
+        sign = case positiveSign of
+          PlusRequired -> char '+' $> id <|> char '-' $> negate
+          PlusOptional -> char '-' $> negate <|> optionalAs id (char '+')
+          PlusIllegal  -> pure id
+        _decimal = atomic (sign <*> decimal unsigned)
+        _hexadecimal = atomic (sign <*> hexadecimal unsigned)
+        _octal = atomic (sign <*> octal unsigned)
+        _binary = atomic (sign <*> binary unsigned)
+        _number = atomic (sign <*> number unsigned)
 
 type FloatingParsers :: *
 data FloatingParsers = FloatingParsers {}
 
-mkUnsignedFloating :: NumericDesc -> IntegerParsers -> GenericNumeric -> FloatingParsers
+mkUnsignedFloating :: NumericDesc -> IntegerParsers CanHoldUnsigned -> GenericNumeric -> FloatingParsers
 mkUnsignedFloating NumericDesc{..} nat gen = FloatingParsers {}
 
 mkSignedFloating :: NumericDesc -> FloatingParsers -> FloatingParsers
@@ -27,13 +277,13 @@ mkSignedFloating NumericDesc{..} unsigned = FloatingParsers {}
 type CombinedParsers :: *
 data CombinedParsers = CombinedParsers {}
 
-mkUnsignedCombined :: NumericDesc -> IntegerParsers -> FloatingParsers -> CombinedParsers
+mkUnsignedCombined :: NumericDesc -> IntegerParsers CanHoldUnsigned -> FloatingParsers -> CombinedParsers
 mkUnsignedCombined NumericDesc{..} natural floating = CombinedParsers {}
 
 mkSignedCombined :: NumericDesc -> CombinedParsers -> CombinedParsers
 mkSignedCombined NumericDesc{..} unsigned = CombinedParsers {}
 
-lexemeInteger :: (forall a. Parsec a -> Parsec a) -> IntegerParsers -> IntegerParsers
+lexemeInteger :: (forall a. Parsec a -> Parsec a) -> IntegerParsers c -> IntegerParsers c
 lexemeInteger = const id
 
 lexemeFloating :: (forall a. Parsec a -> Parsec a) -> FloatingParsers -> FloatingParsers

--- a/src/Text/Gigaparsec/Token/Numeric.hs
+++ b/src/Text/Gigaparsec/Token/Numeric.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE DataKinds, KindSignatures, MultiParamTypeClasses, AllowAmbiguousTypes, FlexibleInstances, FlexibleContexts, UndecidableInstances, ApplicativeDo #-}
+{-# LANGUAGE DataKinds, KindSignatures, ConstraintKinds, MultiParamTypeClasses, AllowAmbiguousTypes, FlexibleInstances, FlexibleContexts, UndecidableInstances, ApplicativeDo #-}
 -- TODO: refine
 module Text.Gigaparsec.Token.Numeric (module Text.Gigaparsec.Token.Numeric) where
 

--- a/src/Text/Gigaparsec/Token/Numeric.hs
+++ b/src/Text/Gigaparsec/Token/Numeric.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE Safe #-}
+-- TODO: refine
+module Text.Gigaparsec.Token.Numeric (module Text.Gigaparsec.Token.Numeric) where
+
+import Text.Gigaparsec (Parsec)
+import Text.Gigaparsec.Token.Descriptions
+import Text.Gigaparsec.Token.Generic (GenericNumeric)
+
+type IntegerParsers :: *
+data IntegerParsers = IntegerParsers {}
+
+mkUnsigned :: NumericDesc -> GenericNumeric -> IntegerParsers
+mkUnsigned NumericDesc{..} gen = IntegerParsers {}
+
+mkSigned :: NumericDesc -> IntegerParsers -> IntegerParsers
+mkSigned NumericDesc{..} unsigned = IntegerParsers {}
+
+type FloatingParsers :: *
+data FloatingParsers = FloatingParsers {}
+
+mkUnsignedFloating :: NumericDesc -> IntegerParsers -> GenericNumeric -> FloatingParsers
+mkUnsignedFloating NumericDesc{..} nat gen = FloatingParsers {}
+
+mkSignedFloating :: NumericDesc -> FloatingParsers -> FloatingParsers
+mkSignedFloating NumericDesc{..} unsigned = FloatingParsers {}
+
+type CombinedParsers :: *
+data CombinedParsers = CombinedParsers {}
+
+mkUnsignedCombined :: NumericDesc -> IntegerParsers -> FloatingParsers -> CombinedParsers
+mkUnsignedCombined NumericDesc{..} natural floating = CombinedParsers {}
+
+mkSignedCombined :: NumericDesc -> CombinedParsers -> CombinedParsers
+mkSignedCombined NumericDesc{..} unsigned = CombinedParsers {}
+
+lexemeInteger :: (forall a. Parsec a -> Parsec a) -> IntegerParsers -> IntegerParsers
+lexemeInteger = const id
+
+lexemeFloating :: (forall a. Parsec a -> Parsec a) -> FloatingParsers -> FloatingParsers
+lexemeFloating = const id
+
+lexemeCombined :: (forall a. Parsec a -> Parsec a) -> CombinedParsers -> CombinedParsers
+lexemeCombined = const id

--- a/src/Text/Gigaparsec/Token/Numeric.hs
+++ b/src/Text/Gigaparsec/Token/Numeric.hs
@@ -265,7 +265,7 @@ mkSigned NumericDesc{..} unsigned =
         _binary = atomic (sign <*> binary unsigned)
         _number = atomic (sign <*> number unsigned)
 
-type FloatingParsers :: *
+{-type FloatingParsers :: *
 data FloatingParsers = FloatingParsers {}
 
 mkUnsignedFloating :: NumericDesc -> IntegerParsers CanHoldUnsigned -> GenericNumeric -> FloatingParsers
@@ -281,13 +281,14 @@ mkUnsignedCombined :: NumericDesc -> IntegerParsers CanHoldUnsigned -> FloatingP
 mkUnsignedCombined NumericDesc{..} natural floating = CombinedParsers {}
 
 mkSignedCombined :: NumericDesc -> CombinedParsers -> CombinedParsers
-mkSignedCombined NumericDesc{..} unsigned = CombinedParsers {}
+mkSignedCombined NumericDesc{..} unsigned = CombinedParsers {}-}
 
 lexemeInteger :: (forall a. Parsec a -> Parsec a) -> IntegerParsers c -> IntegerParsers c
 lexemeInteger = const id
 
-lexemeFloating :: (forall a. Parsec a -> Parsec a) -> FloatingParsers -> FloatingParsers
+{-lexemeFloating :: (forall a. Parsec a -> Parsec a) -> FloatingParsers -> FloatingParsers
 lexemeFloating = const id
 
 lexemeCombined :: (forall a. Parsec a -> Parsec a) -> CombinedParsers -> CombinedParsers
 lexemeCombined = const id
+-}

--- a/src/Text/Gigaparsec/Token/Numeric.hs
+++ b/src/Text/Gigaparsec/Token/Numeric.hs
@@ -104,102 +104,73 @@ data IntegerParsers canHold = IntegerParsers { decimal :: Parsec Integer
                                              , octal :: Parsec Integer
                                              , binary :: Parsec Integer
                                              , number :: Parsec Integer
-                                             , decimal8 :: forall a. canHold 'B8 a => Parsec a
-                                             , hexadecimal8 :: forall a. canHold 'B8 a => Parsec a
-                                             , octal8 :: forall a. canHold 'B8 a => Parsec a
-                                             , binary8 :: forall a. canHold 'B8 a => Parsec a
-                                             , number8 :: forall a. canHold 'B8 a => Parsec a
-                                             , decimal16 :: forall a. canHold 'B16 a => Parsec a
-                                             , hexadecimal16 :: forall a. canHold 'B16 a => Parsec a
-                                             , octal16 :: forall a. canHold 'B16 a => Parsec a
-                                             , binary16 :: forall a. canHold 'B16 a => Parsec a
-                                             , number16 :: forall a. canHold 'B16 a => Parsec a
-                                             , decimal32 :: forall a. canHold 'B32 a => Parsec a
-                                             , hexadecimal32 :: forall a. canHold 'B32 a => Parsec a
-                                             , octal32 :: forall a. canHold 'B32 a => Parsec a
-                                             , binary32 :: forall a. canHold 'B32 a => Parsec a
-                                             , number32 :: forall a. canHold 'B32 a => Parsec a
-                                             , decimal64 :: forall a. canHold 'B64 a => Parsec a
-                                             , hexadecimal64 :: forall a. canHold 'B64 a => Parsec a
-                                             , octal64 :: forall a. canHold 'B64 a => Parsec a
-                                             , binary64 :: forall a. canHold 'B64 a => Parsec a
-                                             , number64 :: forall a. canHold 'B64 a => Parsec a
+                                             , _bounded :: forall (bits :: Bits) t. canHold bits t => Proxy bits -> Parsec Integer -> Int -> Parsec t
                                              }
 
-mkIntegerParsers :: forall (canHold :: (Bits -> * -> Constraint)).
-                    (forall (bits :: Bits) t. canHold bits t => Proxy bits -> Parsec Integer -> Int -> Parsec t)
-                 -> Parsec Integer
-                 -> Parsec Integer
-                 -> Parsec Integer
-                 -> Parsec Integer
-                 -> Parsec Integer
-                 -> IntegerParsers canHold
-mkIntegerParsers bounded decimal hexadecimal octal binary number = IntegerParsers {..}
-  where decimalBounded :: forall (bits :: Bits) t. canHold bits t => Parsec t
-        decimalBounded = bounded (Proxy @bits) decimal 10
+decimalBounded :: forall (bits :: Bits) canHold t. canHold bits t => IntegerParsers canHold -> Parsec t
+decimalBounded IntegerParsers{..} = _bounded (Proxy @bits) decimal 10
 
-        hexadecimalBounded :: forall (bits :: Bits) t. canHold bits t => Parsec t
-        hexadecimalBounded = bounded (Proxy @bits) hexadecimal 16
+hexadecimalBounded :: forall (bits :: Bits) canHold t. canHold bits t => IntegerParsers canHold -> Parsec t
+hexadecimalBounded IntegerParsers{..} = _bounded (Proxy @bits) hexadecimal 16
 
-        octalBounded :: forall (bits :: Bits) t. canHold bits t => Parsec t
-        octalBounded = bounded (Proxy @bits) octal 8
+octalBounded :: forall (bits :: Bits) canHold t. canHold bits t => IntegerParsers canHold -> Parsec t
+octalBounded IntegerParsers{..} = _bounded (Proxy @bits) octal 8
 
-        binaryBounded :: forall (bits :: Bits) t. canHold bits t => Parsec t
-        binaryBounded = bounded (Proxy @bits) binary 2
+binaryBounded :: forall (bits :: Bits) canHold t. canHold bits t => IntegerParsers canHold -> Parsec t
+binaryBounded IntegerParsers{..} = _bounded (Proxy @bits) binary 2
 
-        numberBounded :: forall (bits :: Bits) t. canHold bits t => Parsec t
-        numberBounded = bounded (Proxy @bits) number 10
+numberBounded :: forall (bits :: Bits) canHold t. canHold bits t => IntegerParsers canHold -> Parsec t
+numberBounded IntegerParsers{..} = _bounded (Proxy @bits) number 10
 
-        decimal8 :: forall t. canHold 'B8 t => Parsec t
-        decimal8 = decimalBounded @'B8
-        decimal16 :: forall t. canHold 'B16 t => Parsec t
-        decimal16 = decimalBounded @'B16
-        decimal32 :: forall t. canHold 'B32 t => Parsec t
-        decimal32 = decimalBounded @'B32
-        decimal64 :: forall t. canHold 'B64 t => Parsec t
-        decimal64 = decimalBounded @'B64
+decimal8 :: canHold 'B8 a => IntegerParsers canHold -> Parsec a
+decimal8 = decimalBounded @'B8
+hexadecimal8 :: canHold 'B8 a => IntegerParsers canHold -> Parsec a
+hexadecimal8 = hexadecimalBounded @'B8
+octal8 :: canHold 'B8 a => IntegerParsers canHold -> Parsec a
+octal8 = octalBounded @'B8
+binary8 :: canHold 'B8 a => IntegerParsers canHold -> Parsec a
+binary8 = binaryBounded @'B8
+number8 :: canHold 'B8 a => IntegerParsers canHold -> Parsec a
+number8 = numberBounded @'B8
 
-        hexadecimal8 :: forall t. canHold 'B8 t => Parsec t
-        hexadecimal8 = hexadecimalBounded @'B8
-        hexadecimal16 :: forall t. canHold 'B16 t => Parsec t
-        hexadecimal16 = hexadecimalBounded @'B16
-        hexadecimal32 :: forall t. canHold 'B32 t => Parsec t
-        hexadecimal32 = hexadecimalBounded @'B32
-        hexadecimal64 :: forall t. canHold 'B64 t => Parsec t
-        hexadecimal64 = hexadecimalBounded @'B64
+decimal16 :: canHold 'B16 a => IntegerParsers canHold -> Parsec a
+decimal16 = decimalBounded @'B16
+hexadecimal16 :: canHold 'B16 a => IntegerParsers canHold -> Parsec a
+hexadecimal16 = hexadecimalBounded @'B16
+octal16 :: canHold 'B16 a => IntegerParsers canHold -> Parsec a
+octal16 = octalBounded @'B16
+binary16 :: canHold 'B16 a => IntegerParsers canHold -> Parsec a
+binary16 = binaryBounded @'B16
+number16 :: canHold 'B16 a => IntegerParsers canHold -> Parsec a
+number16 = numberBounded @'B16
 
-        octal8 :: forall t. canHold 'B8 t => Parsec t
-        octal8 = octalBounded @'B8
-        octal16 :: forall t. canHold 'B16 t => Parsec t
-        octal16 = octalBounded @'B16
-        octal32 :: forall t. canHold 'B32 t => Parsec t
-        octal32 = octalBounded @'B32
-        octal64 :: forall t. canHold 'B64 t => Parsec t
-        octal64 = octalBounded @'B64
+decimal32 :: canHold 'B32 a => IntegerParsers canHold -> Parsec a
+decimal32 = decimalBounded @'B32
+hexadecimal32 :: canHold 'B32 a => IntegerParsers canHold -> Parsec a
+hexadecimal32 = hexadecimalBounded @'B32
+octal32 :: canHold 'B32 a => IntegerParsers canHold -> Parsec a
+octal32 = octalBounded @'B32
+binary32 :: canHold 'B32 a => IntegerParsers canHold -> Parsec a
+binary32 = binaryBounded @'B32
+number32 :: canHold 'B32 a => IntegerParsers canHold -> Parsec a
+number32 = numberBounded @'B32
 
-        binary8 :: forall t. canHold 'B8 t => Parsec t
-        binary8 = binaryBounded @'B8
-        binary16 :: forall t. canHold 'B16 t => Parsec t
-        binary16 = binaryBounded @'B16
-        binary32 :: forall t. canHold 'B32 t => Parsec t
-        binary32 = binaryBounded @'B32
-        binary64 :: forall t. canHold 'B64 t => Parsec t
-        binary64 = binaryBounded @'B64
-
-        number8 :: forall t. canHold 'B8 t => Parsec t
-        number8 = numberBounded @'B8
-        number16 :: forall t. canHold 'B16 t => Parsec t
-        number16 = numberBounded @'B16
-        number32 :: forall t. canHold 'B32 t => Parsec t
-        number32 = numberBounded @'B32
-        number64 :: forall t. canHold 'B64 t => Parsec t
-        number64 = numberBounded @'B64
+decimal64 :: canHold 'B64 a => IntegerParsers canHold -> Parsec a
+decimal64 = decimalBounded @'B64
+hexadecimal64 :: canHold 'B64 a => IntegerParsers canHold -> Parsec a
+hexadecimal64 = hexadecimalBounded @'B64
+octal64 :: canHold 'B64 a => IntegerParsers canHold -> Parsec a
+octal64 = octalBounded @'B64
+binary64 :: canHold 'B64 a => IntegerParsers canHold -> Parsec a
+binary64 = binaryBounded @'B64
+number64 :: canHold 'B64 a => IntegerParsers canHold -> Parsec a
+number64 = numberBounded @'B64
 
 mkUnsigned :: NumericDesc -> GenericNumeric -> IntegerParsers CanHoldUnsigned
-mkUnsigned desc@NumericDesc{..} gen = mkIntegerParsers bounded decimal hexadecimal octal binary number
-  where bounded :: forall (bits :: Bits) t. CanHoldUnsigned bits t
-                => Proxy bits -> Parsec Integer -> Int -> Parsec t
-        bounded _ num _radix = mapMaybeS
+mkUnsigned desc@NumericDesc{..} gen = IntegerParsers {..}
+  where _bounded :: forall (bits :: Bits) t. CanHoldUnsigned bits t
+                 => Proxy bits -> Parsec Integer -> Int -> Parsec t
+        _bounded _ num _radix = mapMaybeS
           (\n -> if n >= 0 && n <= upperUnsigned @bits then Just (fromInteger n) else Nothing)
           num
 
@@ -244,11 +215,17 @@ mkUnsigned desc@NumericDesc{..} gen = mkIntegerParsers bounded decimal hexadecim
                   | otherwise = id
 
 mkSigned :: NumericDesc -> IntegerParsers c -> IntegerParsers CanHoldSigned
-mkSigned NumericDesc{..} unsigned =
-  mkIntegerParsers bounded _decimal _hexadecimal _octal _binary _number
-  where bounded :: forall (bits :: Bits) t. CanHoldSigned bits t
-                => Proxy bits -> Parsec Integer -> Int -> Parsec t
-        bounded _ num _radix = mapMaybeS
+mkSigned NumericDesc{..} unsigned = IntegerParsers {
+    decimal = _decimal,
+    hexadecimal = _hexadecimal,
+    octal = _octal,
+    binary = _binary,
+    number = _number,
+    ..
+  }
+  where _bounded :: forall (bits :: Bits) t. CanHoldSigned bits t
+                 => Proxy bits -> Parsec Integer -> Int -> Parsec t
+        _bounded _ num _radix = mapMaybeS
           (\n -> if n >= lowerSigned @bits && n <= upperSigned @bits
                  then Just (fromInteger n)
                  else Nothing)
@@ -284,7 +261,14 @@ mkSignedCombined :: NumericDesc -> CombinedParsers -> CombinedParsers
 mkSignedCombined NumericDesc{..} unsigned = CombinedParsers {}-}
 
 lexemeInteger :: (forall a. Parsec a -> Parsec a) -> IntegerParsers c -> IntegerParsers c
-lexemeInteger = const id
+lexemeInteger lexe IntegerParsers{..} = IntegerParsers {
+    decimal = lexe decimal,
+    hexadecimal = lexe hexadecimal,
+    octal = lexe octal,
+    binary = lexe binary,
+    number = lexe number,
+    _bounded = \n b radix -> lexe (_bounded n b radix)
+  }
 
 {-lexemeFloating :: (forall a. Parsec a -> Parsec a) -> FloatingParsers -> FloatingParsers
 lexemeFloating = const id

--- a/src/Text/Gigaparsec/Token/Patterns.hs
+++ b/src/Text/Gigaparsec/Token/Patterns.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TemplateHaskell, TypeOperators #-}
 module Text.Gigaparsec.Token.Patterns (overloadedStrings) where
 

--- a/src/Text/Gigaparsec/Token/Patterns.hs
+++ b/src/Text/Gigaparsec/Token/Patterns.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE TemplateHaskell, TypeOperators #-}
+module Text.Gigaparsec.Token.Patterns (overloadedStrings) where
+
+import Text.Gigaparsec (Parsec)
+import Text.Gigaparsec.Token.Lexer (lexeme, sym)
+
+import Data.String (IsString(fromString))
+import Language.Haskell.TH.Syntax (Q, Dec, Exp)
+
+{-|
+When given a quoted reference to a 'Text.Gigaparsec.Token.Lexer', for example
+@[|lexer|]@, this function will synthesise an `IsString` instance that will
+allow string literals to serve as @Parsec ()@. These literals will parse symbols
+in the language associated with the lexer, followed by consuming valid whitespace.
+
+@since 0.2.2.0
+-}
+overloadedStrings :: Q Exp   -- ^ the quoted 'Text.Gigaparsec.Token.Lexer'
+                  -> Q [Dec] -- ^ a synthesised `IsString` instance.
+overloadedStrings qlexer = [d|
+    instance u ~ () => IsString (Parsec u) where
+      fromString = sym (lexeme $qlexer) -- TODO: one day, $qlexer.lexeme.sym
+  |]

--- a/src/Text/Gigaparsec/Token/Symbol.hs
+++ b/src/Text/Gigaparsec/Token/Symbol.hs
@@ -29,7 +29,6 @@ mkSymbol SymbolDesc{..} NameDesc{..} = Symbol { softKeyword = _softKeyword caseS
                                               , softOperator = _softOperator hardOperators operatorLetter
                                               }
 
-
 mkSym :: SymbolDesc -> Symbol -> (String -> Parsec ())
 mkSym SymbolDesc{..} Symbol{..} str
   | Set.member str hardKeywords  = softKeyword str

--- a/src/Text/Gigaparsec/Token/Symbol.hs
+++ b/src/Text/Gigaparsec/Token/Symbol.hs
@@ -1,14 +1,21 @@
 {-# LANGUAGE Safe #-}
 {-# LANGUAGE RecordWildCards #-}
-module Text.Gigaparsec.Token.Symbol (module Text.Gigaparsec.Token.Symbol) where
+module Text.Gigaparsec.Token.Symbol (
+    Symbol, softKeyword, softOperator, mkSymbol, mkSym, lexeme
+  ) where
 
-import Text.Gigaparsec (Parsec, void{-, notFollowedBy-})
-import Text.Gigaparsec.Char (string)
-import Text.Gigaparsec.Token.Descriptions ( SymbolDesc(SymbolDesc, hardKeywords, hardOperators)
-                                          , NameDesc(NameDesc)
+import Text.Gigaparsec (Parsec, void, notFollowedBy, atomic, (<|>), empty)
+import Text.Gigaparsec.Char (string, satisfy, char, strings)
+import Text.Gigaparsec.Token.Descriptions ( SymbolDesc(SymbolDesc, hardKeywords, hardOperators, caseSensitive)
+                                          , NameDesc(NameDesc, identifierLetter, operatorLetter)
+                                          , CharPredicate
                                           )
 
-import Data.Set qualified as Set (member)
+import Data.Set qualified as Set (member, toList, fromList, null)
+import Data.Char (toUpper, toLower, isLetter)
+import Text.Gigaparsec.Errors.Combinator (amend, emptyWide)
+import Data.Set (Set)
+import Data.Maybe (mapMaybe)
 
 type Symbol :: *
 data Symbol = Symbol { softKeyword :: !(String -> Parsec ())
@@ -16,20 +23,52 @@ data Symbol = Symbol { softKeyword :: !(String -> Parsec ())
                      }
 
 mkSymbol :: SymbolDesc -> NameDesc -> Symbol
-mkSymbol SymbolDesc{} NameDesc{} = Symbol { softKeyword = void . string  -- TODO:
-                                          , softOperator = void . string -- TODO:
-                                          }
+-- TODO: needs to be case insensitive for softKeyword
+-- TODO: need to handle max-operator semantics for softOperator
+mkSymbol SymbolDesc{..} NameDesc{..} = Symbol { softKeyword = _softKeyword caseSensitive identifierLetter
+                                              , softOperator = _softOperator hardOperators operatorLetter
+                                              }
+
 
 mkSym :: SymbolDesc -> Symbol -> (String -> Parsec ())
 mkSym SymbolDesc{..} Symbol{..} str
   | Set.member str hardKeywords  = softKeyword str
   | Set.member str hardOperators = softOperator str
-  | otherwise                    = void (string str)
+  | otherwise                    = void (atomic (string str))
 
 lexeme :: (forall a. Parsec a -> Parsec a) -> Symbol -> Symbol
 lexeme _lex Symbol{..} = Symbol { softKeyword = _lex . softKeyword
                                 , softOperator = _lex . softKeyword
                                 }
+
+-- TODO: requirement on non-empty name
+_softKeyword :: Bool -> CharPredicate -> String -> Parsec ()
+_softKeyword caseSensitive letter kw
+  | caseSensitive = atomic (nfb letter caseString)
+  | otherwise     = atomic (nfb letter (string kw))
+  where nfb Nothing p = void p
+        nfb (Just c) p = p *> notFollowedBy (satisfy c)
+        n = length kw
+        caseChar c
+          | isLetter c = char (toUpper c) <|> char (toLower c)
+          | otherwise  = char c
+        caseString = atomic (amend (traverse caseChar kw))
+                 <|> emptyWide (fromIntegral n)
+
+-- TODO: requirement on non-empty name
+-- TODO: trie-based implementation
+_softOperator :: Set String -> CharPredicate -> String -> Parsec ()
+_softOperator hardOperators letter op =
+  if Set.null ends then atomic (string op *> notFollowedBy letter')
+  else atomic (string op *> notFollowedBy (void letter' <|> void (strings ends)))
+  where ends = Set.fromList (mapMaybe (flip strip op) (Set.toList hardOperators))
+        letter' = maybe empty satisfy letter
+        strip [] [] = Nothing
+        strip [] str = Just str
+        strip (c:pre) (c':str)
+          | c == c'   = strip pre str
+          | otherwise = Nothing
+        strip _ _ = Nothing
 
 -- TODO: HasField instances for the dot/comma/etc?
 -- FIXME: to make these work, well need to move sym into Symbol?

--- a/src/Text/Gigaparsec/Token/Symbol.hs
+++ b/src/Text/Gigaparsec/Token/Symbol.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE RecordWildCards #-}
+module Text.Gigaparsec.Token.Symbol (module Text.Gigaparsec.Token.Symbol) where
+
+import Text.Gigaparsec (Parsec, void{-, notFollowedBy-})
+import Text.Gigaparsec.Char (string)
+import Text.Gigaparsec.Token.Descriptions ( SymbolDesc(SymbolDesc, hardKeywords, hardOperators)
+                                          , NameDesc(NameDesc)
+                                          )
+
+import Data.Set qualified as Set (member)
+
+type Symbol :: *
+data Symbol = Symbol { softKeyword :: !(String -> Parsec ())
+                     , softOperator :: !(String -> Parsec ())
+                     }
+
+mkSymbol :: SymbolDesc -> NameDesc -> Symbol
+mkSymbol SymbolDesc{} NameDesc{} = Symbol { softKeyword = void . string  -- TODO:
+                                          , softOperator = void . string -- TODO:
+                                          }
+
+mkSym :: SymbolDesc -> Symbol -> (String -> Parsec ())
+mkSym SymbolDesc{..} Symbol{..} str
+  | Set.member str hardKeywords  = softKeyword str
+  | Set.member str hardOperators = softOperator str
+  | otherwise                    = void (string str)
+
+lexeme :: (forall a. Parsec a -> Parsec a) -> Symbol -> Symbol
+lexeme _lex Symbol{..} = Symbol { softKeyword = _lex . softKeyword
+                                , softOperator = _lex . softKeyword
+                                }
+
+-- TODO: HasField instances for the dot/comma/etc?
+-- FIXME: to make these work, well need to move sym into Symbol?
+{-dot :: Symbol -> Parsec ()
+dot =
+-}

--- a/src/Text/Gigaparsec/Token/Symbol.hs
+++ b/src/Text/Gigaparsec/Token/Symbol.hs
@@ -63,12 +63,9 @@ _softOperator hardOperators letter op =
   else atomic (string op *> notFollowedBy (void letter' <|> void (strings ends)))
   where ends = Set.fromList (mapMaybe (flip strip op) (Set.toList hardOperators))
         letter' = maybe empty satisfy letter
-        strip [] [] = Nothing
-        strip [] str = Just str
-        strip (c:pre) (c':str)
-          | c == c'   = strip pre str
-          | otherwise = Nothing
-        strip _ _ = Nothing
+        strip []      str@(:){}          = Just str
+        strip (c:pre) (c':str) | c == c' = strip pre str
+        strip _       _                  = Nothing
 
 -- TODO: HasField instances for the dot/comma/etc?
 -- FIXME: to make these work, well need to move sym into Symbol?

--- a/src/Text/Gigaparsec/Token/Symbol.hs
+++ b/src/Text/Gigaparsec/Token/Symbol.hs
@@ -36,8 +36,8 @@ mkSym SymbolDesc{..} Symbol{..} str
   | otherwise                    = void (atomic (string str))
 
 lexeme :: (forall a. Parsec a -> Parsec a) -> Symbol -> Symbol
-lexeme _lex Symbol{..} = Symbol { softKeyword = _lex . softKeyword
-                                , softOperator = _lex . softKeyword
+lexeme lexe Symbol{..} = Symbol { softKeyword = lexe . softKeyword
+                                , softOperator = lexe . softOperator
                                 }
 
 -- TODO: requirement on non-empty name

--- a/src/Text/Gigaparsec/Token/Text.hs
+++ b/src/Text/Gigaparsec/Token/Text.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE Safe #-}
+-- TODO: refine, move to Internal
+module Text.Gigaparsec.Token.Numeric (module Text.Gigaparsec.Token.Numeric) where
+
+import Text.Gigaparsec (Parsec, void, (<|>), empty, filterS)
+import Text.Gigaparsec.Char (char, digit, hexDigit, octDigit, bit, satisfy)
+import Text.Gigaparsec.Token.Descriptions (TextDesc(..), EscapeDesc(..), NumericEscape)
+import Text.Gigaparsec.Token.Generic (GenericNumeric(zeroAllowedDecimal, zeroAllowedHexadecimal, zeroAllowedOctal, zeroAllowedBinary))
+
+type TextParsers :: * -> *
+data TextParsers t = TextParsers { unicode :: Parsec t
+                                 , ascii :: Parsec t
+                                 , latin1 :: Parsec t
+                                 }
+
+-- I want the convenient naming, sue me
+type StringParsers :: *
+type StringParsers = TextParsers String
+
+type CharacterParsers :: *
+type CharacterParsers = TextParsers Char
+
+mkCharacterParsers :: TextDesc -> Escape -> CharacterParsers
+mkCharacterParsers TextDesc{..} escape = TextParsers {..}
+  where unicode = lit uncheckedUniLetter
+        ascii = lit (filterS (<= '\x7f') uncheckedUniLetter)
+        latin1 = lit (filterS (<= '\xff') uncheckedUniLetter)
+
+        quote = char characterLiteralEnd
+        lit c = quote *> c <* quote
+        uncheckedUniLetter = escapeChar escape <|> graphic
+
+        -- FIXME: nope!
+        graphic = maybe empty satisfy graphicCharacter
+
+type Escape :: *
+data Escape = Escape { escapeCode :: !(Parsec Char)
+                     , escapeBegin :: !(Parsec ())
+                     , escapeChar :: !(Parsec Char)
+                     }
+
+mkEscape :: EscapeDesc -> GenericNumeric -> Escape
+mkEscape EscapeDesc{..} gen = Escape {..}
+  where
+    escapeBegin = void (char escBegin)
+    escapeCode = escMapped <|> numericEscape
+    escapeChar = escapeBegin *> escapeCode
+
+    escMapped = undefined --TODO:
+    numericEscape = decimalEsc <|> hexadecimalEsc <|> octalEsc <|> binaryEsc
+
+    decimalEsc = fromDesc 10 decimalEscape (zeroAllowedDecimal gen) digit
+    hexadecimalEsc = fromDesc 16 hexadecimalEscape (zeroAllowedHexadecimal gen) hexDigit
+    octalEsc = fromDesc 8 octalEscape (zeroAllowedOctal gen) octDigit
+    binaryEsc = fromDesc 2 binaryEscape (zeroAllowedBinary gen) bit
+
+    fromDesc :: Int -> NumericEscape -> Parsec Integer -> Parsec Char -> Parsec Char
+    fromDesc radix _ integer digit = undefined --TODO:
+
+lexemeText :: (forall a. Parsec a -> Parsec a) -> TextParsers t -> TextParsers t
+lexemeText lexe TextParsers{..} = TextParsers {
+    unicode = lexe unicode,
+    ascii = lexe ascii,
+    latin1 = lexe latin1
+  }

--- a/src/Text/Gigaparsec/Token/Text.hs
+++ b/src/Text/Gigaparsec/Token/Text.hs
@@ -2,13 +2,16 @@
 -- TODO: refine, move to Internal
 module Text.Gigaparsec.Token.Text (module Text.Gigaparsec.Token.Text) where
 
-import Text.Gigaparsec (Parsec, void, (<|>), empty, filterS, mapMaybeS)
+import Text.Gigaparsec (Parsec, void, (<|>), empty, filterS, mapMaybeS, somel, (<~>), ($>), atomic)
 import Text.Gigaparsec.Char (char, digit, hexDigit, octDigit, bit, satisfy, trie)
 import Text.Gigaparsec.Token.Descriptions (TextDesc(..), EscapeDesc(..), NumericEscape (NumericSupported, NumericIllegal, numDigits, maxValue, prefix), CharPredicate, NumberOfDigits (Exactly, AtMost, Unbounded))
 import Text.Gigaparsec.Token.Generic (GenericNumeric(zeroAllowedDecimal, zeroAllowedHexadecimal, zeroAllowedOctal, zeroAllowedBinary))
-import Data.Char (isSpace, chr, ord)
+import Data.Char (isSpace, chr, ord, digitToInt)
 import Data.Map qualified as Map (insert, map)
-import Data.List.NonEmpty (NonEmpty((:|)))
+import Data.List.NonEmpty (NonEmpty((:|)), sort)
+import Text.Gigaparsec.Registers (Reg, make, unsafeMake, gets, modify, put, get)
+import Text.Gigaparsec.Combinator (guardS)
+import Control.Applicative (liftA3)
 
 type TextParsers :: * -> *
 data TextParsers t = TextParsers { unicode :: Parsec t
@@ -70,18 +73,45 @@ mkEscape EscapeDesc{..} gen = Escape {..}
              | c < toInteger (ord maxValue) = Just (chr (fromInteger c))
              | otherwise = Nothing
 
-    atMost :: Word -> Int -> Parsec Char -> Parsec Integer
-    atMost _ _ _ = empty -- TODO:
+    atMost' :: Int -> Parsec Char -> Reg r Word -> Parsec Integer
+    atMost' radix dig atMostR =
+      -- FIXME: surely this is an inefficient mess with the translations?
+      somel (\n d -> n * toInteger radix + toInteger (digitToInt d)) 0
+            (guardS (gets atMostR (> 0)) *> dig <* modify atMostR pred)
 
-    oneOfExactly :: Word -> [Word] -> Int -> Parsec Char -> Parsec Integer
-    oneOfExactly _ _ _ _ = empty --TODO:
+    atMost :: Word -> Int -> Parsec Char -> Parsec Integer
+    atMost n radix dig = make n (atMost' radix dig)
+
+    exactly :: Word -> Word -> Int -> Parsec Char -> NonEmpty Word -> Parsec Integer
+    exactly n full radix dig _reqDigits = make n $ \atMostR ->
+      mapMaybeS (\(num, m) -> if m == full then Just num else Nothing)
+                (atMost' radix dig atMostR <~> gets atMostR (full -))
+
+    oneOfExactly' :: NonEmpty Word -> Word -> Word -> [Word] -> Int -> Parsec Char -> Reg r Word -> Parsec Integer
+    oneOfExactly' reqDigits digits m [] radix dig digitsParsed =
+      exactly digits m radix dig reqDigits <* put digitsParsed digits
+    oneOfExactly' reqDigits digits m (n:ns) radix dig digitsParsed =
+      let theseDigits = exactly digits m radix dig reqDigits
+          restDigits =
+                atomic (Just <$> oneOfExactly' reqDigits (n - m) n ns radix dig digitsParsed
+                     <* modify digitsParsed (+ digits))
+            <|> put digitsParsed digits $> Nothing
+          combine !x Nothing !_ = x
+          -- digits is removed here, because it's been added before the get
+          combine x (Just y) e = x * toInteger radix ^ (e - digits) + y
+      in liftA3 combine theseDigits restDigits (get digitsParsed)
+
+    oneOfExactly :: NonEmpty Word -> Int -> Parsec Char -> Parsec Integer
+    oneOfExactly ns radix dig =
+      let reqDigits@(m :| ms) = sort ns
+      in unsafeMake (oneOfExactly' reqDigits m m ms radix dig)
 
     fromDesc :: Int -> NumericEscape -> Parsec Integer -> Parsec Char -> Parsec Char
     fromDesc !_ NumericIllegal !_ !_ = empty
     fromDesc radix NumericSupported{..} integer dig = case numDigits of
-      Unbounded -> boundedChar integer maxValue prefix radix
-      AtMost n -> boundedChar (atMost n radix dig) maxValue prefix radix
-      Exactly (n :| ns) -> boundedChar (oneOfExactly n ns radix digit) maxValue prefix radix
+      Unbounded  -> boundedChar integer maxValue prefix radix
+      AtMost n   -> boundedChar (atMost n radix dig) maxValue prefix radix
+      Exactly ns -> boundedChar (oneOfExactly ns radix dig) maxValue prefix radix
 
 lexemeText :: (forall a. Parsec a -> Parsec a) -> TextParsers t -> TextParsers t
 lexemeText lexe TextParsers{..} = TextParsers {

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -8,6 +8,7 @@ import Text.Gigaparsec.CombinatorTests qualified as Combinator
 import Text.Gigaparsec.DebugTests qualified as Debug
 import Text.Gigaparsec.ExprTests qualified as Expr
 import Text.Gigaparsec.ErrorsTests qualified as Errors
+import Text.Gigaparsec.TokenTests qualified as Token
 
 main :: IO ()
 main = defaultMain $ testGroup "gigaparsec"
@@ -16,5 +17,6 @@ main = defaultMain $ testGroup "gigaparsec"
   , Combinator.tests
   , Expr.tests
   , Errors.tests
+  , Token.tests
   , Debug.tests
   ]

--- a/test/Text/Gigaparsec/Token/NamesTests.hs
+++ b/test/Text/Gigaparsec/Token/NamesTests.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE BlockArguments, OverloadedLists #-}
+module Text.Gigaparsec.Token.NamesTests where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.ExpectedFailure
+
+import Text.Gigaparsec
+import Text.Gigaparsec.Char (spaces)
+import Text.Gigaparsec.Token.Descriptions
+import Text.Gigaparsec.Token.Names (mkNames, lexeme, identifier, Names)
+
+--import Text.Gigaparsec.Internal.Require
+import Text.Gigaparsec.Internal.Test
+import Control.Monad (forM_)
+import Data.Char (isLetter, isAlphaNum)
+import Text.Gigaparsec.Internal.TestError
+
+tests :: TestTree
+tests = testGroup "Names"
+  [ identifierTests
+  , userDefinedOperatorTests
+  ]
+
+identifierTests :: TestTree
+identifierTests = testGroup "identifier should"
+  [ testCase "parse valid identifiers" do
+      identCases (Just isLetter) (Just isAlphaNum) True
+        [ "hello1" --> Just "hello1"
+        , "7f" --> Nothing
+        , "hi" --> Just "hi"
+        , "x7" --> Just "x7"
+        ]
+      identCases (Just isLetter) Nothing True
+        [ "x" --> Just "x"
+        , "y" --> Just "y"
+        , "hi" --> Just "h"
+        , "x7" --> Just "x"
+        ]
+      identCases (Just (== '🙂')) (Just isAlphaNum) True
+        [ "🙂ello1" --> Just "🙂ello1"
+        , "df" --> Nothing
+        , "🙂i" --> Just "🙂i"
+        , "🙂7" --> Just "🙂7"
+        , "🙂🙂" --> Just "🙂"
+        ]
+  , testCase "fail to parse valid keywords" do
+      identCases (Just isLetter) (Just isAlphaNum) True
+        [ "keyword" --> Nothing
+        , "KEYWORD" --> Just "KEYWORD"
+        , "keyword1" --> Just "keyword1"
+        ]
+  , testCase "point at the correct place for the error" do
+      case testParseAll (identifier basicNames) "keyword" of
+        Failure (TestError pos _) -> pos @?= (1, 1)
+        _ -> assertFailure "parser must fail"
+  , expectFailBecause "no unexpected filter" $ testCase "report the correct label" do
+      case testParseAll (identifier basicNames) "HARD" of
+        Failure (TestError _ (VanillaError unex exs rs width)) -> do
+          width @?= 4
+          unex @?= Just (Named "keyword HARD")
+          exs @?= [Named "identifier"]
+          rs @?= []
+        _ -> assertFailure "parser must fail"
+  , testCase "work in the presence of case insensitivity with respect to keywords" do
+      identCases (Just isLetter) (Just isAlphaNum) False
+        [ "HARD" --> Nothing
+        , "hard" --> Nothing
+        , "HArd" --> Nothing
+        , "harD" --> Nothing
+        , "keyword" --> Nothing
+        , "Keyword" --> Nothing
+        , "keyWORD" --> Nothing
+        , "KEYword" --> Nothing
+        ]
+  ]
+
+userDefinedOperatorTests :: TestTree
+userDefinedOperatorTests = testGroup "user defined operator should"
+  []
+
+(-->) :: a -> b -> (a, b)
+(-->) = (,)
+
+identCases :: CharPredicate -> CharPredicate -> Bool -> [(String, Maybe String)] -> Assertion
+identCases start letter sensitive ts =
+  do let p = identifier (namesFor start letter sensitive)
+     forM_ ts $ \(sym, res) ->
+        case res of
+          Nothing -> ensureFails p sym
+          Just r  -> testParse p sym @?= Success r
+
+namesFor :: CharPredicate -> CharPredicate -> Bool -> Names
+namesFor start letter sensitive = lexeme (<* spaces) $
+  mkNames (plainName { identifierStart = start, identifierLetter = letter })
+          (plainSymbol { caseSensitive = sensitive
+                       , hardKeywords = ["keyword", "HARD"]
+                       , hardOperators = ["+", "<", "<="]
+                       })
+
+basicNames :: Names
+basicNames = namesFor (Just isLetter) (Just isAlphaNum) True

--- a/test/Text/Gigaparsec/TokenTests.hs
+++ b/test/Text/Gigaparsec/TokenTests.hs
@@ -1,0 +1,9 @@
+module Text.Gigaparsec.TokenTests where
+
+import Test.Tasty
+import Text.Gigaparsec.Token.NamesTests as Names
+
+tests :: TestTree
+tests = testGroup "Token"
+  [ Names.tests
+  ]


### PR DESCRIPTION
- Avoided redundant transitive instances by doing type-level natural
number comparisons
- Use custom type errors to explain why the instance is not available
- The downside is that the constraints are not extensible - i.e: users
cannot create their own instances for their own numeric types.
- I think the only way to solve this while keeping the nice type errors
would be to rely on overlapping instances (but there might be a trick
that I am unaware of)