### PR TITLE
Accept pattern synonyms when deriving constructors

### DIFF
--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -20,7 +20,7 @@ name:               gigaparsec
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version:            0.2.5.1
+version:            0.2.6.0
 
 -- A short (one-line) description of the package.
 synopsis:

--- a/src/Text/Gigaparsec/Patterns.hs
+++ b/src/Text/Gigaparsec/Patterns.hs
@@ -175,7 +175,8 @@ splitFun :: Type -> Q (Q Type -> Q Type, [Type])
 splitFun (ForallT bndrs ctx ty) = do
   kindSigs <- isExtEnabled KindSignatures
   let bndrs' = if kindSigs then bndrs else map sanitiseStarT bndrs
-  return (forallT bndrs' (pure ctx), splitFun' ty)
+  (forallT', ty') <- splitFun ty
+  return (forallT bndrs' (pure ctx) . forallT', ty')
 splitFun ty                     = return (id, splitFun' ty)
 
 splitFun' :: Type -> [Type]


### PR DESCRIPTION
This PR extends `deriveDeferredConstructors` and `deriveLiftedConstructors` to accept pattern synonyms.

Includes documentation and a version bump to `0.2.6.0`, but no changelog entry or tests.