### PR TITLE
Generate lexer combinators

### DIFF
--- a/gigaparsec.cabal
+++ b/gigaparsec.cabal
@@ -117,12 +117,17 @@ library
                       Text.Gigaparsec.Internal.Errors.ErrorItem,
                       Text.Gigaparsec.Internal.Errors.ParseError,
                       Text.Gigaparsec.Internal.Require,
+                      Text.Gigaparsec.Internal.TH.DecUtils,
+                      Text.Gigaparsec.Internal.TH.TypeUtils,
+                      Text.Gigaparsec.Internal.TH.VersionAgnostic,
                       Text.Gigaparsec.Internal.Token.BitBounds,
                       Text.Gigaparsec.Internal.Token.Errors,
                       Text.Gigaparsec.Internal.Token.Generic,
                       Text.Gigaparsec.Internal.Token.Lexer,
                       Text.Gigaparsec.Internal.Token.Names,
                       Text.Gigaparsec.Internal.Token.Numeric,
+                      Text.Gigaparsec.Internal.Token.Patterns.IntegerParsers,
+                      Text.Gigaparsec.Internal.Token.Patterns.LexerCombinators,
                       Text.Gigaparsec.Internal.Token.Symbol,
                       Text.Gigaparsec.Internal.Token.Text,
 
@@ -216,8 +221,25 @@ benchmark perf-test
     hs-source-dirs:  benchmarks
     build-depends:
         gigaparsec,
-        --containers >= 0.6 && < 0.7,
         gauge >= 0.1 && < 0.3,
         deepseq >= 1.4 && < 1.6
 
     main-is:          Main.hs
+
+library examples
+    import:             warnings, extensions, base
+    default-language:   Haskell2010
+    hs-source-dirs:     examples
+
+    ghc-options: -ddump-to-file -ddump-simpl -ddump-splices -ddump-file-prefix=Foo
+
+    build-depends:      
+        gigaparsec,
+        containers >= 0.6 && < 0.7
+    
+    exposed-modules:
+        ExprLang,
+        ExprLang.Parser,
+        ExprLang.Lexer,
+        ExprLang.Lexer.IntConfig,
+        ExprLang.AST

--- a/src/Text/Gigaparsec/Internal/TH/DecUtils.hs
+++ b/src/Text/Gigaparsec/Internal/TH/DecUtils.hs
@@ -2,8 +2,8 @@
 module Text.Gigaparsec.Internal.TH.DecUtils (
   module Text.Gigaparsec.Internal.TH.DecUtils
   ) where
-import Text.Gigaparsec.Internal.TH.VersionAgnostic (Quote, Name, Exp, Dec)
+import Text.Gigaparsec.Internal.TH.VersionAgnostic (Q, Name, Exp, Dec)
 import Language.Haskell.TH (normalB, clause, funD)
     
-funDsingleClause :: Quote m => Name -> m Exp -> m Dec
+funDsingleClause :: Name -> Q Exp -> Q Dec
 funDsingleClause x body = funD x [clause [] (normalB body) []]

--- a/src/Text/Gigaparsec/Internal/TH/DecUtils.hs
+++ b/src/Text/Gigaparsec/Internal/TH/DecUtils.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE Safe #-}
+module Text.Gigaparsec.Internal.TH.DecUtils (
+  module Text.Gigaparsec.Internal.TH.DecUtils
+  ) where
+import Text.Gigaparsec.Internal.TH.VersionAgnostic (Quote, Name, Exp, Dec)
+import Language.Haskell.TH (normalB, clause, funD)
+    
+funDsingleClause :: Quote m => Name -> m Exp -> m Dec
+funDsingleClause x body = funD x [clause [] (normalB body) []]

--- a/src/Text/Gigaparsec/Internal/TH/DecUtils.hs
+++ b/src/Text/Gigaparsec/Internal/TH/DecUtils.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE Safe #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+
 module Text.Gigaparsec.Internal.TH.DecUtils (
   module Text.Gigaparsec.Internal.TH.DecUtils
   ) where

--- a/src/Text/Gigaparsec/Internal/TH/TypeUtils.hs
+++ b/src/Text/Gigaparsec/Internal/TH/TypeUtils.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE Safe #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/src/Text/Gigaparsec/Internal/TH/TypeUtils.hs
+++ b/src/Text/Gigaparsec/Internal/TH/TypeUtils.hs
@@ -115,7 +115,6 @@ getRecordFields :: Info -> Q [(Name, Type)]
 getRecordFields i = case i of
   TyConI (DataD _ _ _ _ cstrs _) -> concat <$> mapM getFieldNames cstrs
   TyConI (NewtypeD _ _ _ _ cstr _) -> getFieldNames cstr
-  TyConI (TypeDataD _ _ _ cstrs) -> concat <$> mapM getFieldNames cstrs
   DataConI _ _ tname -> getRecordFields =<< reify tname
   info -> fail $ concat ["getRecordFields: given info is not for a record: `", pprint info, "`"]
   where

--- a/src/Text/Gigaparsec/Internal/TH/TypeUtils.hs
+++ b/src/Text/Gigaparsec/Internal/TH/TypeUtils.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+Module      : Text.Gigaparsec.Internal.TH.TypeUtils
+Description : Common Template Haskell Utils
+License     : BSD-3-Clause
+Maintainer  : Jamie Willis, Gigaparsec Maintainers
+Stability   : experimental
+
+Common utils for manipulating Template Haskell Type AST.
+
+@since 0.2.2.0
+-}
+module Text.Gigaparsec.Internal.TH.TypeUtils (module Text.Gigaparsec.Internal.TH.TypeUtils) where
+
+import Text.Gigaparsec.Internal.TH.VersionAgnostic
+
+import Data.Bifunctor (Bifunctor (bimap))
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Language.Haskell.TH (pprint)
+
+-- When KindSignatures is off, the default (a :: *) that TH generates is broken!
+sanitiseStarT :: TyVarBndr flag -> TyVarBndr flag
+sanitiseStarT = recTyVarBndr mkPlainTV (\x y -> const (mkPlainTV x y))
+
+-- | Remove stars from binder annotations when we don't have `KindSignatures` enabled.
+sanitiseBndrStars :: [TyVarBndr flag] -> Q [TyVarBndr flag]
+sanitiseBndrStars bndrs = do
+  kindSigs <- isExtEnabled KindSignatures
+  return (if kindSigs then bndrs else map sanitiseStarT bndrs)
+
+sanitiseTypeStars :: Type -> Q Type
+sanitiseTypeStars = cataType go
+ where
+  go :: TypeF (Q Type) -> Q Type
+  go (ForallTF bnds ctx tp) =
+    ForallT <$> mapM helpBnd bnds <*> sequence ctx <*> tp
+  go (ForallVisTF bnds tp) = mkForallVisT <$> mapM helpBnd bnds <*> tp
+  go e = embedType <$> sequence e
+
+  helpBnd :: TyVarBndrF flag (Q Type) -> Q (TyVarBndr flag)
+  helpBnd (PlainTVF n f) = return $ mkPlainTV n f
+  helpBnd (KindedTVF n f ~_) = return $ mkPlainTV n f
+
+unTyVarBndrF :: TyVarBndrF flag k -> (Name, flag, Maybe k)
+unTyVarBndrF = recTyVarBndrF (,,Nothing) (\x y z -> (x, y, Just z))
+
+reTyVarBndr :: Name -> flag -> Maybe Type -> TyVarBndr flag
+reTyVarBndr n f mt = case mt of
+  Nothing -> mkPlainTV n f
+  Just t -> mkKindedTV n f t
+
+getBndrFName :: TyVarBndrF flag k -> Name
+getBndrFName = (\(a, _, _) -> a) . unTyVarBndrF
+
+removeUnusedTVars :: Type -> Type
+removeUnusedTVars = zygoType typeFreeVarsAlg go
+ where
+  go :: TypeF (Set Name, Type) -> Type
+  go (ForallTF bnds ctx (tpNames, tp)) =
+    let (ctxNames, ctx') = unzip ctx
+        -- All names that *do* occur in the rest of the type/constraints
+        allFreeNames = Set.unions (tpNames : ctxNames)
+        (bnds', _) = foldr discardUnusedTVars ([], allFreeNames) bnds
+     in ForallT bnds' ctx' tp
+  go (ForallVisTF bnds (tpNames, tp)) =
+    let (bnds', _) = foldr discardUnusedTVars ([], tpNames) bnds
+     in ForallVisT bnds' tp
+  go e = embedType (snd <$> e)
+
+  discardUnusedTVars ::
+    TyVarBndrF s (Set Name, Type) ->
+    ([TyVarBndr s], Set Name) ->
+    ([TyVarBndr s], Set Name)
+  discardUnusedTVars bnd (bnds, names) =
+    let (n, f, mk) = unTyVarBndrF bnd
+     in if n `Set.member` names
+          -- We keep n, and add any free vars in its kind (if it has one)
+          then
+            ( reTyVarBndr n f (snd <$> mk) : bnds
+            , Set.union (maybe Set.empty fst mk) names
+            )
+          -- We discard n as it does not appear in subterms
+          else (bnds, names)
+
+typeFreeVarsAlg :: TypeF (Set Name) -> Set Name
+typeFreeVarsAlg = go
+ where
+  go :: TypeF (Set Name) -> Set Name
+  go (VarTF x) = Set.singleton x
+  go (ForallTF bnds ctx tp) = handleBnds bnds (Set.unions $ (tp : ctx))
+  go (ForallVisTF bnds tp) = handleBnds bnds tp
+  go e = foldr Set.union Set.empty e
+
+  handleBnds :: [TyVarBndrF flag (Set Name)] -> Set Name -> Set Name
+  handleBnds bnds ns =
+    let (as, ks) =
+          bimap Set.fromList Set.unions $ unzip (map bndrFreeAndBoundNames bnds)
+     in Set.difference (Set.union ks ns) as
+
+  bndrFreeAndBoundNames :: TyVarBndrF flag (Set Name) -> (Name, Set Name)
+  bndrFreeAndBoundNames (PlainTVF x _) = (x, Set.empty)
+  bndrFreeAndBoundNames (KindedTVF x _ k) = (x, k)
+
+typeFreeVars :: Type -> Set Name
+typeFreeVars = cataType typeFreeVarsAlg
+
+getRecordFields :: Info -> Q [(Name, Type)]
+getRecordFields i = case i of
+  TyConI (DataD _ _ _ _ cstrs _) -> concat <$> mapM getFieldNames cstrs
+  TyConI (NewtypeD _ _ _ _ cstr _) -> getFieldNames cstr
+  TyConI (TypeDataD _ _ _ cstrs) -> concat <$> mapM getFieldNames cstrs
+  DataConI _ _ tname -> getRecordFields =<< reify tname
+  info -> fail $ concat ["getRecordFields: given info is not for a record: `", pprint info, "`"]
+  where
+    getFieldNames :: Con -> Q [(Name, Type)]
+    getFieldNames (RecC _ tps) = return $ map (\(nm, _, tp) -> (nm, tp)) tps
+    getFieldNames c = fail ("getRecordFields: Constructor is not a record: " ++ pprint c)

--- a/src/Text/Gigaparsec/Internal/TH/VersionAgnostic.hs
+++ b/src/Text/Gigaparsec/Internal/TH/VersionAgnostic.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE Trustworthy #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
 {-# LANGUAGE TemplateHaskell, CPP, PatternSynonyms, LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/src/Text/Gigaparsec/Internal/TH/VersionAgnostic.hs
+++ b/src/Text/Gigaparsec/Internal/TH/VersionAgnostic.hs
@@ -70,13 +70,13 @@ module Text.Gigaparsec.Internal.TH.VersionAgnostic (
   -- * Template Haskell select re-exports
   module TH,
   module TH.Lib,
+  TH.pprint,
 #if !(MIN_VERSION_template_haskell(2,17,0))
   Quote(..),
   DocLoc(..),
   pattern MulArrowT,
   getDoc,
   putDoc,
-  TH.pprint
 #endif
   ) where
 

--- a/src/Text/Gigaparsec/Internal/TH/VersionAgnostic.hs
+++ b/src/Text/Gigaparsec/Internal/TH/VersionAgnostic.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TemplateHaskell, CPP, PatternSynonyms, LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveTraversable, PatternSynonyms #-}
@@ -68,12 +69,35 @@ module Text.Gigaparsec.Internal.TH.VersionAgnostic (
   zygoType,
   -- * Template Haskell select re-exports
   module TH,
+  module TH.Lib,
+#if !(MIN_VERSION_template_haskell(2,17,0))
+  Quote(..),
+  DocLoc(..),
+  pattern MulArrowT,
+  getDoc,
+  putDoc,
+  TH.pprint
+#endif
   ) where
 
-
+#if (MIN_VERSION_template_haskell(2,17,0))
 import Language.Haskell.TH.Syntax hiding (TyVarBndr(..), Specificity)
+import Language.Haskell.TH qualified as TH hiding (TyVarBndr(..), Specificity)
 import Language.Haskell.TH.Syntax qualified as TH hiding (TyVarBndr(..), Specificity)
 import Language.Haskell.TH.Syntax qualified as THAll
+import Language.Haskell.TH.Lib as TH.Lib
+#else
+import Data.IORef (atomicModifyIORef')
+import Language.Haskell.TH.Syntax hiding (TyVarBndr(..), Specificity, newName)
+import Language.Haskell.TH qualified as TH hiding (TyVarBndr(..), Specificity)
+import Language.Haskell.TH.Syntax qualified as TH hiding (TyVarBndr(..), Specificity)
+import Language.Haskell.TH.Syntax qualified as THAll
+import Language.Haskell.TH.Lib as TH.Lib
+#endif
+
+
+import Control.Applicative (liftA2)
+
 import GHC.Generics (Generic)
 import Data.Kind (Constraint)
 import Data.Bitraversable (bisequence)
@@ -86,21 +110,23 @@ import Data.Bitraversable (bisequence)
 type TyVarBndrF :: * -> * -> *
 type TyVarBndrF flag k = Either (Name, flag) (Name, flag, k)
 
+
 {-# COMPLETE PlainTVF, KindedTVF #-}
 
-pattern PlainTVF :: Name -> flag -> TyVarBndrF flag k
-pattern PlainTVF n f = Left (n, f)
 
+pattern PlainTVF :: Name -> flag -> TyVarBndrF flag k
 pattern KindedTVF :: Name -> flag -> k -> TyVarBndrF flag k
+pattern PlainTVF n f = Left (n, f)
 pattern KindedTVF n f knd = Right (n, f, knd)
+
 
 recTyVarBndrF 
   :: (Name -> flag -> a) -- The `PlainTV` case
   -> (Name -> flag -> k -> a) -- The `KindedTV` case
   -> TyVarBndrF flag k
   -> a
-recTyVarBndrF f _ (PlainTVF nm flag) = f nm flag
-recTyVarBndrF _ g (KindedTVF nm flag k) = g nm flag k
+recTyVarBndrF f _ (PlainTVF nm ~flag) = f nm flag
+recTyVarBndrF _ g (KindedTVF nm ~flag k) = g nm flag k
 
 {-| Unrolls one step of recursion on `TyVarBndr`.
 
@@ -286,7 +312,7 @@ versions of template haskell.
 type TyVarBndr :: * -> *
 type TyVarBndr flag = THAll.TyVarBndr flag
 #else
-type TyVarBndr flag = TH.TyVarBndr 
+type TyVarBndr flag = THAll.TyVarBndr 
 #endif
 
 {-| The specificity of a binding; whether it is inferred or given by a user.
@@ -304,22 +330,18 @@ type Specificity = ()
 
 First case is for `TH.PlainTV`, the second for `TH.KindedTV`.
 -}
-#if MIN_VERSION_template_haskell(2,17,0)
 recTyVarBndr 
   :: (Name -> flag -> a) -- The `PlainTV` case
   -> (Name -> flag -> Kind -> a) -- The `KindedTV` case
   -> TyVarBndr flag 
   -> a
+#if MIN_VERSION_template_haskell(2,17,0)
 recTyVarBndr f _ (THAll.PlainTV nm flag) = f nm flag
 recTyVarBndr _ g (THAll.KindedTV nm flag k) = g nm flag k
 #else
-recTyVarBndr 
-  :: (Name -> () -> a) -- The `PlainTV` case
-  -> (Name -> () -> Kind -> a) -- The `KindedTV` case
-  -> TyVarBndr () 
-  -> a
-recTyVarBndr f _ (TH.PlainTV nm) = f nm ()
-recTyVarBndr _ g (TH.KindedTV nm k) = g nm () k
+  -- TODO: this is quite naughty
+recTyVarBndr f _ (THAll.PlainTV nm) = f nm undefined
+recTyVarBndr _ g (THAll.KindedTV nm k) = g nm undefined k
 #endif
 
 {-| Version-safe `TH.PlainTV` constructor for `TyVarBndr`.
@@ -337,8 +359,8 @@ mkKindedTV :: Name -> flag -> Type -> TyVarBndr flag
 mkPlainTV  = THAll.PlainTV
 mkKindedTV = THAll.KindedTV
 #else
-mkPlainTV  n _ = TH.PlainTV n
-mkKindedTV n _ = TH.KindedTV n
+mkPlainTV  n ~_ = THAll.PlainTV n
+mkKindedTV n ~_ = THAll.KindedTV n
 #endif
 
 mkVarT :: Name -> Type
@@ -441,4 +463,47 @@ mkPromotedUInfixT = PromotedUInfixT
 #else
 mkPromotedInfixT = undefined
 mkPromotedUInfixT = undefined
+#endif
+
+
+#if !(MIN_VERSION_template_haskell(2,17,0))
+
+{-
+All of this is ported from:
+https://hackage.haskell.org/package/template-haskell-2.22.0.0/docs/src/Language.Haskell.TH.Syntax.html
+
+-}
+
+class Monad m => Quote m where
+  newName :: String -> m Name
+
+instance Quote IO where
+  newName s = do { n <- atomicModifyIORef' counter (\x -> (x + 1, x))
+                 ; pure (mkNameU s n) }
+instance Quote Q where
+  newName = qNewName
+
+instance (Semigroup a) => Semigroup (Q a) where
+  (<>) = liftA2 (<>)
+instance (Monoid a) => Monoid (Q a) where
+  mempty = pure mempty
+
+
+#endif
+
+
+#if !(MIN_VERSION_template_haskell(2,17,0))
+
+data DocLoc = DeclDoc Name
+
+getDoc :: DocLoc -> Q (Maybe String)
+getDoc _ = pure Nothing
+
+putDoc :: DocLoc -> String -> Q ()
+putDoc _ _ = pure ()
+
+-- Is this awful?
+pattern MulArrowT = ArrowT
+
+
 #endif

--- a/src/Text/Gigaparsec/Internal/TH/VersionAgnostic.hs
+++ b/src/Text/Gigaparsec/Internal/TH/VersionAgnostic.hs
@@ -1,0 +1,444 @@
+{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE TemplateHaskell, CPP, PatternSynonyms, LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveTraversable, PatternSynonyms #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -Wno-missing-kind-signatures #-}
+{-|
+Mostly some utils for dealing with TH in a version-agnostic way.
+-}
+module Text.Gigaparsec.Internal.TH.VersionAgnostic (
+  -- * `TH.Type` Smart Constructors
+  mkVarT,
+  mkConT,
+  mkPromotedT,
+  mkSigT,
+  mkAppT,
+  mkForallT,
+  -- *** Version ≥ 2.11
+  mkInfixT,
+  mkUInfixT,
+  mkParensT,
+  -- *** Version ≥ 2.15
+  mkAppKindT,
+  mkImplicitParamT,
+  -- *** Version ≥ 2.16
+  mkForallVisT,
+  -- *** Version ≥ 2.19
+  mkPromotedInfixT,
+  mkPromotedUInfixT,
+  -- * TyVarBndr
+  -- ** Constructors and Recursors
+  TyVarBndr,
+  mkPlainTV,
+  mkKindedTV,
+  recTyVarBndr,
+  -- ** Base Functor
+  TyVarBndrF,
+  pattern PlainTVF,
+  pattern KindedTVF,
+  recTyVarBndrF,
+  projectBnd,
+  embedBnd,
+  -- * `TH.Type` Base Functor
+  TypeF,
+  -- ** View Patterns
+  pattern ForallTF,
+  pattern ForallVisTF, 
+  pattern AppTF, 
+  pattern AppKindTF, 
+  pattern SigTF, 
+  pattern InfixTF, 
+  pattern UInfixTF, 
+  pattern PromotedInfixTF, 
+  pattern PromotedUInfixTF, 
+  pattern ImplicitParamTF,
+  pattern AtomicF, 
+  pattern ParensTF,
+  pattern VarTF,
+  -- ** Recursion and Corecursion
+  projectType,
+  embedType,
+  cataType,
+  zygoType,
+  -- * Template Haskell select re-exports
+  module TH,
+  ) where
+
+
+import Language.Haskell.TH.Syntax hiding (TyVarBndr(..), Specificity)
+import Language.Haskell.TH.Syntax qualified as TH hiding (TyVarBndr(..), Specificity)
+import Language.Haskell.TH.Syntax qualified as THAll
+import GHC.Generics (Generic)
+import Data.Kind (Constraint)
+import Data.Bitraversable (bisequence)
+
+
+---------------------------------------------------------------------------------------------------
+-- TyVarBndr Base Functor
+
+-- use this defn so that TypeF doesn't need to have two recursion params
+type TyVarBndrF :: * -> * -> *
+type TyVarBndrF flag k = Either (Name, flag) (Name, flag, k)
+
+{-# COMPLETE PlainTVF, KindedTVF #-}
+
+pattern PlainTVF :: Name -> flag -> TyVarBndrF flag k
+pattern PlainTVF n f = Left (n, f)
+
+pattern KindedTVF :: Name -> flag -> k -> TyVarBndrF flag k
+pattern KindedTVF n f knd = Right (n, f, knd)
+
+recTyVarBndrF 
+  :: (Name -> flag -> a) -- The `PlainTV` case
+  -> (Name -> flag -> k -> a) -- The `KindedTV` case
+  -> TyVarBndrF flag k
+  -> a
+recTyVarBndrF f _ (PlainTVF nm flag) = f nm flag
+recTyVarBndrF _ g (KindedTVF nm flag k) = g nm flag k
+
+{-| Unrolls one step of recursion on `TyVarBndr`.
+
+Projects a `TyVarBndr` onto its base functor.
+-}
+projectBnd :: TyVarBndr flag -> TyVarBndrF flag Type
+projectBnd = recTyVarBndr PlainTVF KindedTVF
+
+{-| Rolls up one step of recursion into a `TyVarBndr`.
+
+Embeds a `TyVarBndrF` onto the standard representation `TyVarBndr`.
+-}
+embedBnd :: TyVarBndrF flag Type -> TyVarBndr flag
+embedBnd = recTyVarBndrF mkPlainTV mkKindedTV
+
+---------------------------------------------------------------------------------------------------
+-- Type Base Functor
+
+{-|
+Base functor for `Type`.
+
+Use a hand-rolled base functor, as we then only need to handle the TH version inconsistencies
+in the `embed` and `project` functions.
+-}
+type TypeF :: * -> *
+data TypeF k = 
+    ForallTF_ [TyVarBndrF Specificity k] [k] k
+  | ForallVisTF_ [TyVarBndrF () k] k
+  | AppTF_ k k
+  | AppKindTF_ k k
+  | SigTF_ k k
+  | InfixTF_ k Name k
+  | UInfixTF_ k Name k
+  | PromotedInfixTF_ k Name k
+  | PromotedUInfixTF_ k Name k
+  | ImplicitParamTF_ String k
+  | AtomicF_ Type
+  | ParensTF_ k
+  deriving stock (Functor, Foldable, Traversable, Generic)
+
+{-# COMPLETE ForallTF,ForallVisTF, AppTF, AppKindTF, SigTF, InfixTF, UInfixTF, 
+  PromotedInfixTF, PromotedUInfixTF, ImplicitParamTF, AtomicF, ParensTF #-}
+
+pattern ForallTF :: [TyVarBndrF Specificity k] -> [k] -> k -> TypeF k
+pattern ForallTF bnds ctx t <- ForallTF_ bnds ctx t
+pattern ForallVisTF :: [TyVarBndrF () k] -> k -> TypeF k
+pattern ForallVisTF bnds t <- ForallVisTF_ bnds t 
+pattern AppTF :: k -> k -> TypeF k
+pattern AppTF a b <- AppTF_ a b
+pattern AppKindTF :: k -> k -> TypeF k
+pattern AppKindTF a k <- AppKindTF_ a k
+pattern SigTF :: k -> k -> TypeF k
+pattern SigTF a k <- SigTF_ a k
+pattern InfixTF :: k -> Name -> k -> TypeF k
+pattern InfixTF  a n b      <- InfixTF_ a n b
+pattern UInfixTF :: k -> Name -> k -> TypeF k
+pattern UInfixTF a n b      <- UInfixTF_ a n b
+pattern PromotedInfixTF :: k -> Name -> k -> TypeF k
+pattern PromotedInfixTF a n b <- PromotedInfixTF_ a n b 
+pattern PromotedUInfixTF :: k -> Name -> k -> TypeF k
+pattern PromotedUInfixTF a n b <- PromotedUInfixTF_ a n b 
+pattern ImplicitParamTF :: String -> k -> TypeF k
+pattern ImplicitParamTF x a <- ImplicitParamTF_ x a
+pattern AtomicF :: Type -> TypeF k
+pattern AtomicF  a <- AtomicF_ a
+pattern ParensTF :: k -> TypeF k
+pattern ParensTF a <- ParensTF_ a
+
+pattern VarTF :: Name -> TypeF k
+pattern VarTF nm = AtomicF_ (VarT nm)
+
+-------------------------------------------------------------------------------
+-- Recursion Schemes Stuff
+{-
+To avoid adding a dependency on `recursion-schemes`, we re-implement some of
+the core features from this library.
+The originals can be found at:
+https://hackage.haskell.org/package/recursion-schemes
+-}
+
+type Base :: * -> * -> *
+type family Base t :: * -> *
+
+type Recursive :: * -> Constraint
+class Functor (Base t) => Recursive t where
+  project :: t -> Base t t
+  cata :: (Base t a -> a) -> t -> a
+  cata f = c 
+    where 
+    c = f . fmap c . project
+
+type Corecursive :: * -> Constraint
+class Functor (Base t) => Corecursive t where
+  embed :: Base t t -> t
+
+zygo :: Recursive t => (Base t b -> b) -> (Base t (b, a) -> a) -> t -> a
+zygo f g = snd . cata (bisequence (f . fmap fst, g))
+
+-------------------------------------------------------------------------------
+-- Base Functor Recursive/Corecursive instances
+
+-- | Newtype for `TH.Type`, so we can make an instance of Recursive and Corecursive.
+type THType :: *
+newtype THType = THType {getTHType :: TH.Type}
+
+type instance Base THType = TypeF
+
+projectType :: Type -> TypeF Type
+projectType = fmap getTHType . project . THType
+
+embedType :: TypeF Type -> Type
+embedType = getTHType . embed . fmap THType
+
+cataType :: (TypeF a -> a) -> Type -> a
+cataType alg = cata alg . THType
+
+zygoType :: (TypeF b -> b) -> (TypeF (b, a) -> a) -> Type -> a
+zygoType α β = zygo α β . THType
+
+
+instance Recursive THType where
+  project :: THType -> Base THType THType
+  project = fmap THType . go . getTHType
+    where
+    go :: Type -> Base THType Type
+    go t = case t of
+      ForallT bnds ctx a -> 
+        ForallTF_ (map projectBnd bnds) ctx a
+      AppT a b -> AppTF_ a b
+      SigT a k -> SigTF_ a k
+#if MIN_VERSION_template_haskell(2,11,0)
+      InfixT a n b -> InfixTF_ a n b
+      UInfixT a n b -> UInfixTF_ a n b
+      ParensT k -> ParensTF_ k
+#endif
+#if MIN_VERSION_template_haskell(2,15,0)
+      AppKindT a k -> AppKindTF_ a k
+      ImplicitParamT x a -> ImplicitParamTF_ x a
+#endif
+#if MIN_VERSION_template_haskell(2,16,0)
+      ForallVisT bnds a ->
+        ForallVisTF_ (map projectBnd bnds) a
+#endif
+#if MIN_VERSION_template_haskell(2,19,0)
+      PromotedInfixT a n b -> PromotedInfixTF_ a n b
+      PromotedUInfixT a n b -> PromotedUInfixTF_ a n b
+#endif
+      a -> AtomicF_ a
+    
+instance Corecursive THType where
+  embed :: Base THType THType -> THType
+  embed = THType . go . fmap getTHType 
+    where
+    go :: TypeF Type -> Type
+    go t = case t of
+      ForallTF bnds ctx a -> 
+        mkForallT (map embedBnd bnds) ctx a
+      ForallVisTF bnds a ->
+        mkForallVisT (map embedBnd bnds) a
+      AppTF a b -> mkAppT a b
+      AppKindTF a k -> mkAppKindT a k
+      SigTF a k -> mkSigT a k
+      InfixTF a n b -> mkInfixT a n b
+      UInfixTF a n b -> mkUInfixT a n b
+      PromotedInfixTF a n b -> mkPromotedInfixT a n b
+      PromotedUInfixTF a n b -> mkPromotedUInfixT a n b
+      ImplicitParamTF x a -> mkImplicitParamT x a
+      ParensTF k -> mkParensT k
+      AtomicF a -> a
+
+
+---------------------------------------------------------------------------------------------------
+-- Smart Types and Constructors for version agnosticism
+
+{-| A type variable binder.
+
+__Do not__ pattern match on this, instead use `recTyVarBndr`, which safely handles pattern matching in different
+versions of template haskell.
+
+/Note:/ In TemplateHaskell < 2.17, the flag parameter is ignored.
+-}
+#if MIN_VERSION_template_haskell(2,17,0)
+type TyVarBndr :: * -> *
+type TyVarBndr flag = THAll.TyVarBndr flag
+#else
+type TyVarBndr flag = TH.TyVarBndr 
+#endif
+
+{-| The specificity of a binding; whether it is inferred or given by a user.
+
+__Note:__ In TemplateHaskell < 2.17, this is unit.
+-}
+type Specificity :: *
+#if MIN_VERSION_template_haskell(2,17,0)
+type Specificity = THAll.Specificity
+#else
+type Specificity = ()
+#endif
+
+{-| Version-safe way to pattern match on `TyVarBndr`.
+
+First case is for `TH.PlainTV`, the second for `TH.KindedTV`.
+-}
+#if MIN_VERSION_template_haskell(2,17,0)
+recTyVarBndr 
+  :: (Name -> flag -> a) -- The `PlainTV` case
+  -> (Name -> flag -> Kind -> a) -- The `KindedTV` case
+  -> TyVarBndr flag 
+  -> a
+recTyVarBndr f _ (THAll.PlainTV nm flag) = f nm flag
+recTyVarBndr _ g (THAll.KindedTV nm flag k) = g nm flag k
+#else
+recTyVarBndr 
+  :: (Name -> () -> a) -- The `PlainTV` case
+  -> (Name -> () -> Kind -> a) -- The `KindedTV` case
+  -> TyVarBndr () 
+  -> a
+recTyVarBndr f _ (TH.PlainTV nm) = f nm ()
+recTyVarBndr _ g (TH.KindedTV nm k) = g nm () k
+#endif
+
+{-| Version-safe `TH.PlainTV` constructor for `TyVarBndr`.
+
+In Template Haskell < 2.17, @flag@ can be assumed to be @()@.
+-}
+mkPlainTV :: Name -> flag -> TyVarBndr flag
+
+{-| Version-safe `TH.KindedTV` constructor for `TyVarBndr`.
+
+In Template Haskell < 2.17, @flag@ can be assumed to be @()@.
+-}
+mkKindedTV :: Name -> flag -> Type -> TyVarBndr flag
+#if MIN_VERSION_template_haskell(2,17,0)
+mkPlainTV  = THAll.PlainTV
+mkKindedTV = THAll.KindedTV
+#else
+mkPlainTV  n _ = TH.PlainTV n
+mkKindedTV n _ = TH.KindedTV n
+#endif
+
+mkVarT :: Name -> Type
+mkVarT = VarT
+
+mkConT :: Name -> Type
+mkConT = ConT
+
+mkPromotedT :: Name -> Type
+mkPromotedT = PromotedT
+
+-- | Smart constructor for `ForallT`. Version-safe.
+mkForallT :: [TyVarBndr Specificity] -> Cxt -> Type -> Type
+mkForallT = ForallT
+-- | Smart constructor for `SigT`. Version-safe.
+mkAppT :: Type -> Type -> Type
+mkAppT = AppT
+-- | Smart constructor for `SigT`. Version-safe.
+mkSigT :: Type -> Kind -> Type
+mkSigT = SigT
+
+{-| Smart constructor for `InfixT`.
+
+Equal to `undefined` for template haskell versions < 2.11, so ensure any code that
+uses this will need only be run in versions ≥ 2.11 .
+-}
+mkInfixT :: Type -> Name -> Type -> Type
+{-| Smart constructor for `UInfixT`.
+
+Equal to `undefined` for template haskell versions < 2.11, so ensure any code that
+uses this will need only be run in versions ≥ 2.11 .
+-}
+mkUInfixT :: Type -> Name -> Type -> Type
+
+{-| Smart constructor for `ParensT`.
+
+Equal to `undefined` for template haskell versions < 2.11, so ensure any code that
+uses this will need only be run in versions ≥ 2.11 .
+-}
+mkParensT :: Type -> Type
+#if MIN_VERSION_template_haskell(2,11,0)
+mkParensT = ParensT
+mkUInfixT = UInfixT
+mkInfixT = InfixT
+#else
+mkUInfixT = undefined
+mkParensT = undefined
+mkInfixT = undefined
+#endif
+
+{-| Smart constructor for `AppKindT`.
+
+Equal to `undefined` for template haskell versions < 2.15, so ensure any code that
+uses this will need only be run in versions ≥ 2.15 .
+-}
+mkAppKindT :: Type -> Type -> Type
+
+{-| Smart constructor for `ImplicitParamT`.
+
+Equal to `undefined` for template haskell versions < 2.15, so ensure any code that
+uses this will need only be run in versions ≥ 2.15 .
+-}
+mkImplicitParamT :: String -> Type -> Type
+#if MIN_VERSION_template_haskell(2,15,0)
+mkAppKindT = AppKindT
+mkImplicitParamT = ImplicitParamT
+#else
+mkAppKindT = undefined
+mkImplicitParamT = undefined
+#endif
+
+{-| Smart constructor for `ForallVisT`.
+
+Equal to `undefined` for template haskell versions < 2.16, so ensure any code that
+uses this will need only be run in versions ≥ 2.16 .
+-}
+mkForallVisT :: [TyVarBndr ()] -> Type -> Type
+#if MIN_VERSION_template_haskell(2,16,0)
+mkForallVisT bnds tp = ForallVisT bnds tp
+#else
+mkForallVisT bnds tp = undefined
+#endif
+
+{-| Smart constructor for `PromotedInfixT`.
+
+Equal to `undefined` for template haskell versions < 2.19, so ensure any code that
+uses this will need only be run in versions ≥ 2.19 .
+-}
+mkPromotedInfixT :: Type -> Name -> Type -> Type
+
+{-| Smart constructor for `PromotedUInfixT`.
+
+Equal to `undefined` for template haskell versions < 2.19, so ensure any code that
+uses this will need only be run in versions ≥ 2.19 .
+-}
+mkPromotedUInfixT :: Type -> Name -> Type -> Type
+#if MIN_VERSION_template_haskell(2,19,0)
+mkPromotedInfixT = PromotedInfixT
+mkPromotedUInfixT = PromotedUInfixT
+#else
+mkPromotedInfixT = undefined
+mkPromotedUInfixT = undefined
+#endif

--- a/src/Text/Gigaparsec/Internal/Token/BitBounds.hs
+++ b/src/Text/Gigaparsec/Internal/Token/BitBounds.hs
@@ -46,9 +46,9 @@ data Bits
   -- | 64 bits of data
   | B64
   deriving stock (
-    Show, -- ^ @since 0.4.0.0
-    Eq,   -- ^ @since 0.4.0.0
-    Ord   -- ^ @since 0.4.0.0
+      Show -- ^ @since 0.4.0.0
+    , Eq   -- ^ @since 0.4.0.0
+    , Ord   -- ^ @since 0.4.0.0
     )
 
 type BitWidth :: * -> Bits

--- a/src/Text/Gigaparsec/Internal/Token/BitBounds.hs
+++ b/src/Text/Gigaparsec/Internal/Token/BitBounds.hs
@@ -30,7 +30,10 @@ type family Assert b c where
 {-| The bit-width of certain data.
 
 This is used to help enforce parsers of bounded precision to only return types
-that can losslessly accomodate that precision.
+that can losslessly accommodate that precision.
+
+@since 0.1.0.0
+
 -}
 type Bits :: *
 data Bits
@@ -42,13 +45,19 @@ data Bits
   | B32
   -- | 64 bits of data
   | B64
+  deriving stock (
+    Show, -- ^ @since 0.4.0.0
+    Eq,   -- ^ @since 0.4.0.0
+    Ord   -- ^ @since 0.4.0.0
+    )
 
 type BitWidth :: * -> Bits
 type family BitWidth t where
   BitWidth Integer = 'B64
-  BitWidth Int     = 'B64
+  BitWidth Int     = 'B64 
   BitWidth Word    = 'B64
   BitWidth Word64  = 'B64
+  BitWidth Int64   = 'B64
   BitWidth Natural = 'B64
   BitWidth Int32   = 'B32
   BitWidth Word32  = 'B32
@@ -68,6 +77,7 @@ type family Signedness t s where
   Signedness Int     'Signed   = ()
   Signedness Word    'Unsigned = ()
   Signedness Word64  'Unsigned = ()
+  Signedness Int64   'Signed   = ()
   Signedness Natural 'Unsigned = ()
   Signedness Int32   'Signed   = ()
   Signedness Word32  'Unsigned = ()

--- a/src/Text/Gigaparsec/Internal/Token/Patterns/IntegerParsers.hs
+++ b/src/Text/Gigaparsec/Internal/Token/Patterns/IntegerParsers.hs
@@ -115,24 +115,13 @@ data IntLitBase
   deriving stock (Show, Eq, Ord)
 
 {-|
-The bases (Binary, Octal, ...) of Int literals to be supported.
-
-'IntLitBases' is an instance of `IsList`, so you may use @-XOverloadedLists@ to refer to an 'IntLitBases'.
+Set of all possible `IntLitBase`s.
 
 @since 0.4.0.0
 
 -}
--- TODO: This should just be a `Set IntLitBase`, and `AllBases` is either a constant or a pattern synonym.
-type IntLitBases :: *
-data IntLitBases = 
-    AllBases -- ^ All bases (defined in `IntLitBase`) should be supported.
-  | IntLitBases (Set IntLitBase) -- ^ Only the bases in the given set should be supported.
-
-instance IsList IntLitBases where
-  type Item IntLitBases = IntLitBase
-  fromList = IntLitBases . fromList
-  toList AllBases = intLitBaseList
-  toList (IntLitBases xs) = Set.toList xs
+allBases :: Set IntLitBase
+allBases = Set.fromList [Binary, Octal, Decimal, Hexadecimal]
 
 {-| Determines if the combinators are for 'Signed' or 'Unsigned' int literals.
 
@@ -146,7 +135,7 @@ data SignedOrUnsigned =
     @since 0.4.0.0
     
     -}
-    Signed    -- ^ 
+    Signed 
   | {-|  The literal is unsigned, so is always non-negative.
     
     @since 0.4.0.0
@@ -154,6 +143,12 @@ data SignedOrUnsigned =
     -}
     Unsigned
 
+{-|
+True when `Signed`.
+
+@since 0.4.0.0
+
+-}
 isSigned :: SignedOrUnsigned -> Bool
 isSigned Signed = True
 isSigned Unsigned = False
@@ -190,7 +185,7 @@ data IntegerParserConfig = IntegerParserConfig
     @since 0.4.0.0
 
     -}
-  , bases :: IntLitBases
+  , bases :: Set IntLitBase
     {-|
     When 'True', generate the unbounded integer parsers (e.g. `Text.Gigaparsec.Token.Lexer.decimal`) for each base specified in `bases`.
     
@@ -220,9 +215,8 @@ data IntegerParserConfig = IntegerParserConfig
   , signedOrUnsigned :: SignedOrUnsigned
   }
 
-filterByBase :: IntLitBases -> [(a, IntLitBase)] -> [a]
-filterByBase AllBases = map fst
-filterByBase (IntLitBases bs) = map fst . filter ((`Set.member` bs) . snd)
+filterByBase :: Set IntLitBase -> [(a, IntLitBase)] -> [a]
+filterByBase bs = map fst . filter ((`Set.member` bs) . snd)
 
 filterByWidth :: Bits -> [(Bits, a)] -> [a]
 filterByWidth b = map snd . filter ((== b) . fst)
@@ -339,7 +333,7 @@ emptyIntegerParserConfig =
   IntegerParserConfig
     { prefix = ""
     , widths = Map.empty
-    , bases = IntLitBases Set.empty
+    , bases  = Set.empty
     , includeUnbounded = False
     , signedOrUnsigned = Signed
     , collatedParser = Nothing

--- a/src/Text/Gigaparsec/Internal/Token/Patterns/IntegerParsers.hs
+++ b/src/Text/Gigaparsec/Internal/Token/Patterns/IntegerParsers.hs
@@ -23,7 +23,8 @@ module Text.Gigaparsec.Internal.Token.Patterns.IntegerParsers (
 import Text.Gigaparsec (Parsec)
 import Text.Gigaparsec.Internal.Token.Lexer (natural, integer)
 
-import Language.Haskell.TH.Syntax (Dec (..), Exp, Inline (Inline), Phases (AllPhases), Q, Quote (newName), Type, nameBase)
+
+
 
 import Control.Monad (forM)
 import Data.Bitraversable (bisequence)
@@ -40,7 +41,7 @@ import Language.Haskell.TH (
   sigD,
   varE,
  )
-import Text.Gigaparsec.Internal.TH.VersionAgnostic (Name)
+import Text.Gigaparsec.Internal.TH.VersionAgnostic (Name, Dec (..), Exp, Inline (Inline), Phases (AllPhases), Q, Quote (newName), Type, nameBase)
 import Text.Gigaparsec.Internal.Token.BitBounds (Bits (..))
 import Text.Gigaparsec.Token.Lexer qualified as Lexer
 

--- a/src/Text/Gigaparsec/Internal/Token/Patterns/IntegerParsers.hs
+++ b/src/Text/Gigaparsec/Internal/Token/Patterns/IntegerParsers.hs
@@ -1,0 +1,419 @@
+{-# LANGUAGE Trustworthy #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnicodeSyntax #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
+module Text.Gigaparsec.Internal.Token.Patterns.IntegerParsers (
+  module Text.Gigaparsec.Internal.Token.Patterns.IntegerParsers
+) where
+
+import Text.Gigaparsec (Parsec)
+import Text.Gigaparsec.Internal.Token.Lexer (natural, integer)
+
+import Language.Haskell.TH.Syntax (Dec (..), Exp, Inline (Inline), Phases (AllPhases), Q, Quote (newName), Type, nameBase)
+
+import Control.Monad (forM)
+import Data.Bitraversable (bisequence)
+import Data.Function (on)
+import Data.List (groupBy)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe (fromJust)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Language.Haskell.TH (
+  RuleMatch (FunLike),
+  pragInlD,
+  sigD,
+  varE,
+ )
+import Text.Gigaparsec.Internal.TH.VersionAgnostic (Name)
+import Text.Gigaparsec.Internal.Token.BitBounds (Bits (..))
+import Text.Gigaparsec.Token.Lexer qualified as Lexer
+
+import GHC.Exts (IsList (..))
+import Text.Gigaparsec.Internal.TH.DecUtils (funDsingleClause)
+import Text.Gigaparsec.Internal.Token.Patterns.LexerCombinators
+
+intLitBaseList :: [IntLitBase]
+intLitBaseList = [Binary, Octal, Decimal, Hexadecimal]
+
+-- | Names of the
+integerParsers :: [(Name, IntLitBase)]
+integerParsers =
+  [ 'Lexer.binary
+  , 'Lexer.octal
+  , 'Lexer.decimal
+  , 'Lexer.hexadecimal
+  ]
+    `zip` intLitBaseList
+
+intParsers8Bit :: [(Name, IntLitBase)]
+intParsers8Bit =
+  [ 'Lexer.binary8
+  , 'Lexer.octal8
+  , 'Lexer.decimal8
+  , 'Lexer.hexadecimal8
+  ]
+    `zip` intLitBaseList
+
+intParsers16Bit :: [(Name, IntLitBase)]
+intParsers16Bit =
+  [ 'Lexer.binary16
+  , 'Lexer.octal16
+  , 'Lexer.decimal16
+  , 'Lexer.hexadecimal16
+  ]
+    `zip` intLitBaseList
+
+intParsers32Bit :: [(Name, IntLitBase)]
+intParsers32Bit =
+  [ 'Lexer.binary32
+  , 'Lexer.octal32
+  , 'Lexer.decimal32
+  , 'Lexer.hexadecimal32
+  ]
+    `zip` intLitBaseList
+
+intParsers64Bit :: [(Name, IntLitBase)]
+intParsers64Bit =
+  [ 'Lexer.binary64
+  , 'Lexer.octal64
+  , 'Lexer.decimal64
+  , 'Lexer.hexadecimal64
+  ]
+    `zip` intLitBaseList
+
+{-|
+The base of a numeric literal.
+
+Used in `IntegerParserConfig` to specify which parsers for which bases should be generated.
+
+@since 0.4.0.0
+
+-}
+type IntLitBase :: *
+data IntLitBase
+  = Binary
+  | Octal
+  | Decimal
+  | Hexadecimal
+  deriving stock (Show, Eq, Ord)
+
+{-|
+The bases (Binary, Octal, ...) of Int literals to be supported.
+
+'IntLitBases' is an instance of `IsList`, so you may use @-XOverloadedLists@ to refer to an 'IntLitBases'.
+
+@since 0.4.0.0
+
+-}
+-- TODO: This should just be a `Set IntLitBase`, and `AllBases` is either a constant or a pattern synonym.
+type IntLitBases :: *
+data IntLitBases = 
+    AllBases -- ^ All bases (defined in `IntLitBase`) should be supported.
+  | IntLitBases (Set IntLitBase) -- ^ Only the bases in the given set should be supported.
+
+instance IsList IntLitBases where
+  type Item IntLitBases = IntLitBase
+  fromList = IntLitBases . fromList
+  toList AllBases = intLitBaseList
+  toList (IntLitBases xs) = Set.toList xs
+
+{-| Determines if the combinators are for 'Signed' or 'Unsigned' int literals.
+
+@since 0.4.0.0
+
+-}
+type SignedOrUnsigned :: *
+data SignedOrUnsigned = 
+    {-| The int literal is signed, so can be negative.
+    
+    @since 0.4.0.0
+    
+    -}
+    Signed    -- ^ 
+  | {-|  The literal is unsigned, so is always non-negative.
+    
+    @since 0.4.0.0
+    
+    -}
+    Unsigned
+
+isSigned :: SignedOrUnsigned -> Bool
+isSigned Signed = True
+isSigned Unsigned = False
+
+
+{-|
+This type describes how to generate numeric parsers with `generateIntegerParsers`.
+This includes configuration for which bases and bitwidths to support, and whether to generate
+parsers that can handle multiple bases. 
+
+See the 'emptyIntegerParserConfig' smart constructor to define a 'IntegerParserConfig'.
+
+@since 0.4.0.0
+
+-}
+type IntegerParserConfig :: *
+data IntegerParserConfig = IntegerParserConfig
+  { {-|
+    The string to prepend to each generated parser's name (except for the `collatedParser`, if specified).
+    
+    @since 0.4.0.0
+
+    -}
+    prefix :: String
+    {-| The fixed bit-widths (8-bit, 16-bit, etc/) for which to generate parsers.
+
+    @since 0.4.0.0
+
+    -}
+  , widths :: Map Bits (Q Type)
+    {-|
+    The numeric bases (binary, octal, etc) for which to generate parsers.
+
+    @since 0.4.0.0
+
+    -}
+  , bases :: IntLitBases
+    {-|
+    When 'True', generate the unbounded integer parsers (e.g. `Text.Gigaparsec.Token.Lexer.decimal`) for each base specified in `bases`.
+    
+    @since 0.4.0.0
+
+    -}
+  , includeUnbounded :: Bool
+    {-|
+    Generate a generic integer parser with the given name,
+    at each width (including unbounded) specified by `widths`, that
+    is able to parse each base specified in `bases`.
+  
+    * If 'Nothing', do not generate such a parser.
+    * If @'Just' ""@, then the default name will be @"natural"@  or @"integer"@ when `signedOrUnsigned`
+      is `Unsigned` or `Signed`, respectively.
+
+    @since 0.4.0.0
+
+    -}
+  , collatedParser :: Maybe String
+    {-|
+    Whether or not the parsers to generate are for 'Signed' or 'Unsigned' integers.
+
+    @since 0.4.0.0
+    
+    -}
+  , signedOrUnsigned :: SignedOrUnsigned
+  }
+
+filterByBase :: IntLitBases -> [(a, IntLitBase)] -> [a]
+filterByBase AllBases = map fst
+filterByBase (IntLitBases bs) = map fst . filter ((`Set.member` bs) . snd)
+
+filterByWidth :: Bits -> [(Bits, a)] -> [a]
+filterByWidth b = map snd . filter ((== b) . fst)
+
+-- | Monoidal when; if false, then return `mempty`
+mwhen :: (Monoid m) => Bool -> m -> m
+mwhen True x = x
+mwhen False _ = mempty
+
+groupByBits :: [(Bits, Name)] -> [(Bits, [Name])]
+groupByBits [] = [] -- So that we may assume xs is nonempty in the second line (so we can use head)
+groupByBits xs = map (bisequence (fst . head, map snd)) $ groupBy ((==) `on` fst) xs
+
+{-|
+This function automatically generates lexer combinators for handling signed or unsigned integers.
+
+See 'IntegerParserConfig' for how to configure which combinators are generated.
+
+/Note:/ Due to staging restrictions in Template Haskell, the `IntegerParserConfig` must be
+defined in a separate module to where this function is used.
+Multiple configs can be defined in the same module.
+
+==== __Usage:__
+First, the config must be defined in another module.
+You can define multiple configs in the same module, as long as they are used in a different module.
+
+> {-# LANGUAGE TemplateHaskell, OverloadedLists #-}
+> module IntegerConfigs where
+> …
+> uIntCfg :: IntegerParserConfig
+> uIntCfg = emptyUnsignedIntegerParserConfig {
+>     prefix = "u",
+>     widths = [(B8, [t| Word8 |]), (B32, [t| Word32 |])],
+>     bases = [Hexadecimal, Decimal, Binary],
+>     includeUnbounded = False,
+>     signedOrUnsigned = Unsigned,
+>     collatedParser = Just "natural"
+>   }
+
+Then, we can feed this config, along with a quoted lexer, to `generateIntegerParsers`:
+
+> {-# LANGUAGE TemplateHaskell #-}
+> module Lexer where
+> import IntegerConfigs (uIntCfg)
+> …
+> lexer :: Lexer
+> lexer = …
+>
+> $(generateIntegerParsers [| lexer |] uIntCfg)
+
+This will generate the following combinators,
+
+>    ubinary8 :: Parsec Word8
+>    udecimal8 :: Parsec Word8
+>    uhexadecimal8 :: Parsec Word8
+>    ubinary32 :: Parsec Word32
+>    udecimal3 :: Parsec Word32
+>    uhexadecimal32 :: Parsec Word32
+>    natural8 :: Parsec Word8
+>    natural32 :: Parsec Word32
+
+@since 0.4.0.0
+
+-}
+generateIntegerParsers 
+  :: Q Exp               -- ^ The quoted 'Text.Gigaparsec.Token.Lexer.Lexer'
+  -> IntegerParserConfig -- ^ The configuration describing what numeric combinators to produce.
+  -> Q [Dec]             -- ^ The declarations of the specified combinators.
+generateIntegerParsers lexer cfg@IntegerParserConfig{..} = do
+  (ubNames, concat -> ubDecs) <- unzip <$> mwhen includeUnbounded (lexerUnboundedParsers lexer cfg)
+  (fwNames, fwBits, concat -> fwDecs) <- unzip3 <$> lexerFixedWidthIntParsers lexer cfg
+  let fwBitsNames = groupByBits (zip fwBits fwNames)
+  cDecs <- maybe mempty (mkCollatedParsers ubNames fwBitsNames) collatedParser
+  return $ ubDecs <> fwDecs <> cDecs
+ where
+  mkCollatedParser :: [Name] -> String -> Q Type -> Q [Dec]
+  mkCollatedParser [] _ _ = pure []
+  mkCollatedParser (x : xs) nm tp = do
+    f <- newName nm
+    let body = foldl (\e y -> [|$e <|> $(varE y)|]) [|$(varE x)|] xs
+    sequence
+      [ pragInlD f Inline FunLike AllPhases
+      , sigD f [t|Parsec $tp|]
+      , funDsingleClause f body
+      ]
+  mkCollatedParsers :: [Name] -> [(Bits, [Name])] -> String -> Q [Dec]
+  mkCollatedParsers xs bys nm =
+    mkCollatedParser xs nm [t|Integer|]
+      <> ( concat
+            <$> forM
+              bys
+              ( \(b, nms) ->
+                  let tp = fromJust (Map.lookup b widths)
+                   in mkCollatedParser nms (bitsSuffix b nm) tp
+              )
+         )
+
+bitsSuffix :: Bits -> String -> String
+bitsSuffix B8 = (++ "8")
+bitsSuffix B16 = (++ "16")
+bitsSuffix B32 = (++ "32")
+bitsSuffix B64 = (++ "64")
+
+{-| An empty `IntegerParserConfig`, which will generate nothing when given to `generateIntegerParsers`.
+Extend this using record updates, to tailor a config to your liking.
+
+By default, the `prefix` field is the empty string, which will likely cause issues if you do not override this.
+
+@since 0.4.0.0
+
+-}
+emptyIntegerParserConfig :: IntegerParserConfig
+emptyIntegerParserConfig =
+  IntegerParserConfig
+    { prefix = ""
+    , widths = Map.empty
+    , bases = IntLitBases Set.empty
+    , includeUnbounded = False
+    , signedOrUnsigned = Signed
+    , collatedParser = Nothing
+    }
+
+{-| An empty `IntegerParserConfig` for `Signed` integers, which will generate nothing when given to `generateIntegerParsers`.
+Extend this using record updates, to tailor a config to your liking.
+
+By default, the `prefix` field is the empty string, which will likely cause issues if you do not override this.
+
+@since 0.4.0.0
+
+-}
+emptySignedIntegerParserConfig :: IntegerParserConfig
+emptySignedIntegerParserConfig = emptyIntegerParserConfig{signedOrUnsigned = Signed}
+
+{-| An empty `IntegerParserConfig` for `Unsigned` integers, which will generate nothing when given to `generateIntegerParsers`.
+Extend this using record updates, to tailor a config to your liking.
+
+By default, the `prefix` field is the empty string, which will likely cause issues if you do not override this.
+
+@since 0.4.0.0
+
+-}
+emptyUnsignedIntegerParserConfig :: IntegerParserConfig
+emptyUnsignedIntegerParserConfig = emptyIntegerParserConfig{signedOrUnsigned = Unsigned}
+
+lexerUnboundedParsers ::
+  -- | Quoted Lexer
+  Q Exp ->
+  IntegerParserConfig ->
+  -- | The name and definition of each unbounded parsers
+  Q [(Name, [Dec])]
+lexerUnboundedParsers lexer (IntegerParserConfig{signedOrUnsigned = s, prefix, bases}) = do
+  let proj = if isSigned s then [|integer|] else [|natural|]
+  let parsers = filterByBase bases integerParsers
+  forM
+    parsers
+    ( \p -> do
+        newTp <- getLexerCombinatorType p False
+        mkLexerCombinatorDecWithProj lexer (prefix ++ nameBase p) p (pure newTp) proj
+    )
+
+lexerFixedWidthIntParsers ::
+  -- | The quoted lexer
+  Q Exp ->
+  -- | config
+  IntegerParserConfig ->
+  -- | Name, bitwidth and def of each generated combinator.
+  Q [(Name, Bits, [Dec])]
+lexerFixedWidthIntParsers
+  lexer
+  (IntegerParserConfig{signedOrUnsigned = sign, prefix, bases, widths}) =
+    let proj = if isSigned sign then [|integer|] else [|natural|]
+     in forM
+          parsersToMake
+          ( \(old, bw, newTp) -> do
+              (nm, decs) <-
+                mkLexerCombinatorDecWithProj
+                  lexer
+                  (prefix ++ nameBase old)
+                  old
+                  [t|Parsec $newTp|]
+                  proj
+              return (nm, bw, decs)
+          )
+   where
+    parsersToMake :: [(Name, Bits, Q Type)]
+    parsersToMake =
+      concatMap
+        (\(b, tp) -> map (,b,tp) (parsersAtWidth b))
+        (Map.toList widths)
+    parsersAtWidth :: Bits -> [Name]
+    parsersAtWidth b = filterByBase bases $ case b of
+      B8 -> intParsers8Bit
+      B16 -> intParsers16Bit
+      B32 -> intParsers32Bit
+      B64 -> intParsers64Bit

--- a/src/Text/Gigaparsec/Internal/Token/Patterns/IntegerParsers.hs
+++ b/src/Text/Gigaparsec/Internal/Token/Patterns/IntegerParsers.hs
@@ -377,13 +377,10 @@ lexerUnboundedParsers lexer (IntegerParserConfig{signedOrUnsigned = s, prefix, b
         mkLexerCombinatorDecWithProj lexer (prefix ++ nameBase p) p (pure newTp) proj
     )
 
-lexerFixedWidthIntParsers ::
-  -- | The quoted lexer
-  Q Exp ->
-  -- | config
-  IntegerParserConfig ->
-  -- | Name, bitwidth and def of each generated combinator.
-  Q [(Name, Bits, [Dec])]
+lexerFixedWidthIntParsers
+  :: Q Exp -- ^ The quoted lexer
+  -> IntegerParserConfig -- ^ config
+  -> Q [(Name, Bits, [Dec])] -- ^ Name, bitwidth and def of each generated combinator.
 lexerFixedWidthIntParsers
   lexer
   (IntegerParserConfig{signedOrUnsigned = sign, prefix, bases, widths}) =

--- a/src/Text/Gigaparsec/Internal/Token/Patterns/LexerCombinators.hs
+++ b/src/Text/Gigaparsec/Internal/Token/Patterns/LexerCombinators.hs
@@ -155,14 +155,10 @@ Constructs the combinator using the given type.
 Calculates the definition of the combinator using a typeclass (if possible).
 -}
 mkLexerCombinatorDec
-  -- | The quoted Lexer
-  :: Q Exp
-  -- | The name of the combinator to generate
-  -> String
-  -- | The quoted name of the original combinator
-  -> Name
-  -- | The return type of the new combinator
-  -> Type
+  :: Q Exp -- ^ The quoted Lexer  
+  -> String -- ^ The name of the combinator to generate
+  -> Name -- ^ The quoted name of the original combinator
+  -> Type -- ^ The return type of the new combinator
   -> Q [Dec]
 mkLexerCombinatorDec lexer nm old tp = do
   newX <- newName nm
@@ -180,18 +176,12 @@ Constructs the combinator using the given type.
 Calculates the definition of the combinator using the `LexerField` typeclass (if possible).
 -}
 mkLexerCombinatorDecWithProj 
-  -- | The quoted Lexer
-  :: Q Exp
-  -- | The name of the combinator to generate
-  -> String
-  -- | @old@, The quoted name of the original combinator
-  -> Name
-  -- | The return type of the new combinator
-  -> Q Type
-  -- | projection to precompose the @old@ combinator with
-  -> Q Exp
-  -- | The name of the new combinator and its declaration
-  -> Q (Name, [Dec]) 
+  :: Q Exp -- ^ The quoted Lexer
+  -> String -- ^ The name of the combinator to generate
+  -> Name -- ^ @old@, The quoted name of the original combinator
+  -> Q Type -- ^ The return type of the new combinator
+  -> Q Exp -- ^ projection to precompose the @old@ combinator with
+  -> Q (Name, [Dec]) -- ^ The name of the new combinator and its declaration
 mkLexerCombinatorDecWithProj lexer nm old tp proj = do
   newX <- newName nm
   oldDocs <- getDoc (DeclDoc old)

--- a/src/Text/Gigaparsec/Internal/Token/Patterns/LexerCombinators.hs
+++ b/src/Text/Gigaparsec/Internal/Token/Patterns/LexerCombinators.hs
@@ -52,11 +52,13 @@ import safe Text.Gigaparsec.Internal.Token.Text (TextParsers)
 import Text.Gigaparsec.Internal.TH.DecUtils (funDsingleClause)
 import Text.Gigaparsec.Internal.TH.TypeUtils (removeUnusedTVars, sanitiseBndrStars, sanitiseTypeStars)
 
-import Language.Haskell.TH.Syntax (Dec, DocLoc (DeclDoc), Exp, Inline (Inline), Phases (AllPhases), Q, Quasi (qRecover), Quote (newName), Type (ForallT), addModFinalizer, getDoc, isInstance, nameBase, putDoc, reifyType)
-
-import Language.Haskell.TH (
+import Text.Gigaparsec.Internal.TH.VersionAgnostic (
+  Dec, DocLoc(DeclDoc), Exp, Inline (Inline), Phases (AllPhases), Q, Quasi (qRecover), 
+  Quote (newName), Type (ForallT), addModFinalizer, getDoc, isInstance, 
+  nameBase, putDoc, reifyType,
   RuleMatch (FunLike),
-  Type (AppT, ArrowT, ForallVisT, MulArrowT),
+  Type (AppT, ArrowT, ForallVisT), 
+  pattern MulArrowT,
   clause,
   funD,
   normalB,
@@ -64,7 +66,7 @@ import Language.Haskell.TH (
   pragInlD,
   sigD,
   varE,
- )
+  )
 
 import Data.Bifunctor (Bifunctor (first))
 import Data.Kind (Constraint)

--- a/src/Text/Gigaparsec/Internal/Token/Patterns/LexerCombinators.hs
+++ b/src/Text/Gigaparsec/Internal/Token/Patterns/LexerCombinators.hs
@@ -1,0 +1,359 @@
+{-# LANGUAGE Trustworthy #-}
+
+{-# OPTIONS_HADDOCK hide #-}
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnicodeSyntax #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-unused-do-bind #-}
+
+{- |
+Module      : Text.Gigaparsec.Token.Patterns
+Description : Template Haskell generators to help with patterns
+License     : BSD-3-Clause
+Maintainer  : Jamie Willis, Gigaparsec Maintainers
+Stability   : experimental
+
+This module is currently experimental, and may have bugs depending on the version
+of Haskell, or the extensions enabled. Please report any issues to the maintainers.
+
+@since 0.2.2.0
+-}
+module Text.Gigaparsec.Internal.Token.Patterns.LexerCombinators (
+  module Text.Gigaparsec.Internal.Token.Patterns.LexerCombinators,
+) where
+
+import safe Text.Gigaparsec.Internal.Token.Lexer (
+  Lexeme (
+    charLiteral,
+    multiStringLiteral,
+    names,
+    rawMultiStringLiteral,
+    rawStringLiteral,
+    stringLiteral,
+    symbol
+  ),
+  Lexer (lexeme, space),
+  Space,
+ )
+import safe Text.Gigaparsec.Internal.Token.Names (Names)
+import safe Text.Gigaparsec.Internal.Token.Symbol (Symbol)
+import safe Text.Gigaparsec.Internal.Token.Text (TextParsers)
+
+import Text.Gigaparsec.Internal.TH.DecUtils (funDsingleClause)
+import Text.Gigaparsec.Internal.TH.TypeUtils (removeUnusedTVars, sanitiseBndrStars, sanitiseTypeStars)
+
+import Language.Haskell.TH.Syntax (Dec, DocLoc (DeclDoc), Exp, Inline (Inline), Phases (AllPhases), Q, Quasi (qRecover), Quote (newName), Type (ForallT), addModFinalizer, getDoc, isInstance, nameBase, putDoc, reifyType)
+
+import Language.Haskell.TH (
+  RuleMatch (FunLike),
+  Type (AppT, ArrowT, ForallVisT, MulArrowT),
+  clause,
+  funD,
+  normalB,
+  pprint,
+  pragInlD,
+  sigD,
+  varE,
+ )
+
+import Data.Bifunctor (Bifunctor (first))
+import Data.Kind (Constraint)
+import Data.Maybe (fromMaybe)
+import Text.Gigaparsec.Internal.TH.VersionAgnostic (Name)
+import Text.Gigaparsec.Token.Lexer qualified as Lexer
+
+{-|
+Generates the specified lexer combinators using the quoted lexer.
+
+==== __Usage:__
+
+> import Text.Gigaparsec.Token.Lexer qualified as Lexer
+> import Text.Gigaparsec.Token.Lexer (Lexer)
+> lexer :: Lexer
+> $(lexerCombinators [| lexer |] ['Lexer.lexeme, 'Lexer.fully, 'Lexer.identifier, 'Lexer.stringLiteral])
+
+This will generate the following combinators/functions:
+
+> lexeme :: Lexeme
+> fully :: ∀ a . Parsec a -> Parsec a
+> identifier :: Parsec String
+> stringLiteral :: TextParsers String
+
+These will behave like their counterparts in "Text.Gigaparsec.Token.Lexer", except they will not need
+a 'Lexer' (or its subcomponents) as an argument.
+
+@since 0.4.0.0
+-}
+lexerCombinators
+  :: Q Exp -- The lexer
+  -> [Name] -- The combinators to generate
+  -> Q [Dec]
+lexerCombinators lexer ns = lexerCombinatorsWithNames lexer (zip ns (map nameBase ns))
+
+{-|
+Generates the specified lexer combinators with the specified names using the quoted lexer.
+
+==== __Usage:__
+
+> import Text.Gigaparsec.Token.Lexer qualified as Lexer
+> import Text.Gigaparsec.Token.Lexer (Lexer)
+> lexer :: Lexer
+> $(lexerCombinatorsWithNames [| lexer |] [('Lexer.lexeme, "myLexeme"), ('Lexer.fully, "myFully")])
+
+This will generate the following combinators/functions:
+
+> myLexeme :: Lexeme
+> myFully :: ∀ a . Parsec a -> Parsec a
+
+These will behave like their counterparts in "Text.Gigaparsec.Token.Lexer", except they will not need
+a 'Lexer' (or its subcomponents) as an argument.
+
+@since 0.4.0.0
+-}
+lexerCombinatorsWithNames ::
+  Q Exp -> -- The lexer
+  [(Name, String)] -> -- The combinators to generate
+  Q [Dec]
+lexerCombinatorsWithNames lexer = fmap concat . traverse (uncurry (lexerCombinatorWithName lexer))
+
+{-|
+Create a single lexer combinator with a given name, defined in terms of the lexer.
+-}
+lexerCombinatorWithName
+  :: Q Exp
+  -> Name -- The name of the old combinator
+  -> String -- the new name of the combinator
+  -> Q [Dec]
+lexerCombinatorWithName lexer old nm = do
+  newTp <- getLexerCombinatorType old True
+  mkLexerCombinatorDec lexer nm old newTp
+
+{-| 
+Constructs the combinator using the given type.
+Calculates the definition of the combinator using a typeclass (if possible).
+-}
+mkLexerCombinatorDec ::
+  -- | The quoted Lexer
+  Q Exp ->
+  -- | The name of the combinator to generate
+  String ->
+  -- | The quoted name of the original combinator
+  Name ->
+  -- | The return type of the new combinator
+  Type ->
+  Q [Dec]
+mkLexerCombinatorDec lexer nm old tp = do
+  newX <- newName nm
+  oldDocs <- getDoc (DeclDoc old)
+  let newDocs = fromMaybe "" oldDocs
+  addModFinalizer $ putDoc (DeclDoc newX) newDocs
+  sequence
+    [ pragInlD newX Inline FunLike AllPhases
+    , sigD newX (pure tp)
+    , funD newX [clause [] (normalB [|project $(varE old) $lexer|]) []]
+    ]
+
+{-| 
+Constructs the combinator using the given type.
+Calculates the definition of the combinator using a typeclass (if possible).
+-}
+mkLexerCombinatorDecWithProj ::
+  -- | The quoted Lexer
+  Q Exp ->
+  -- | The name of the combinator to generate
+  String ->
+  -- | @old@, The quoted name of the original combinator
+  Name ->
+  -- | The return type of the new combinator
+  Q Type ->
+  -- | projection to precompose the @old@ combinator with
+  Q Exp ->
+  Q (Name, [Dec]) -- The name of the new combinator and its declaration
+mkLexerCombinatorDecWithProj lexer nm old tp proj = do
+  newX <- newName nm
+  oldDocs <- getDoc (DeclDoc old)
+  let newDocs = fromMaybe "" oldDocs
+  addModFinalizer $ putDoc (DeclDoc newX) newDocs
+  (newX,)
+    <$> sequence
+      [ pragInlD newX Inline FunLike AllPhases
+      , sigD newX tp
+      , funDsingleClause newX [|project ($(varE old) . $proj) $lexer|]
+      ]
+
+{-| 
+Figures out the type of the combinator minus the domain; this will be one of a 'Lexer' component, or any other subcomponents (e.g. 'Symbol' or 'Space').
+Calculates the domain type, and the return type of the new combinator.
+The boolean flag set to True means one should ensure the domain type gives a specific combinator,
+and doesn't lead to an ambiguous return type.
+-}
+getLexerCombinatorType :: Name -> Bool -> Q Type
+getLexerCombinatorType old checkType = do
+  tp <- reifyType old
+  (prefix, dom, _, cod) <-
+    fail (notFunctionTypeMsg old tp) `qRecover` fnTpDomain tp
+  let newTp = prefix cod
+  b <- isInstance ''LexerField [dom]
+  if checkType && not b
+    then catchErrors dom newTp
+    else return $ prefix cod
+ where
+  -- If the quoted name is not at least a function type, then there's no real way to define the combinator :p
+  notFunctionTypeMsg :: Name -> Type -> String
+  notFunctionTypeMsg x tp = concat ["Constant `", nameBase x, "` does not have a function type: ", show tp]
+
+  -- Preventative Errors: catch the cases someone tries to define one of the String or Integer parsers
+  -- they should do these manually or with the bespoke generators!
+  catchErrors :: Type -> Type -> Q a
+  catchErrors dom newTp
+    | old == 'Lexer.ascii = failStringParser old
+    | old == 'Lexer.unicode = failStringParser old
+    | old == 'Lexer.latin1 = failStringParser old
+    | otherwise = fail (notLexerFieldMsg old dom)
+
+  -- Message to give to the user when they give a TextParser field, as there is no way to disambiguate
+  -- exactly *which* TextParser they want.
+  -- And there is no point in implementing a way for the user to ask for this;
+  -- at that point, it would be no more work on the user's end than were they to write a manual definition.
+  failStringParser :: Name -> Q a
+  failStringParser nm =
+    fail $
+      concat
+        [ "Cannot derive a lexer combinator for `"
+        , nameBase nm
+        , "`, as there are many possible "
+        , pprint ''TextParsers
+        , " to define it in terms of, including:"
+        , pprint 'stringLiteral
+        , ", "
+        , pprint 'rawStringLiteral
+        , ", "
+        , pprint 'multiStringLiteral
+        , ", and "
+        , pprint 'rawMultiStringLiteral
+        , "."
+        , "\n You will need to manually define this combinator, as you are then able to pick which TextParser it should use."
+        ]
+
+  -- If the quoted name is not a recognised lexer field, then we should tell the user as much.
+  -- The error may be due to being able to disambiguate the field, rather than the field not existing.
+  notLexerFieldMsg :: Name -> Type -> String
+  notLexerFieldMsg x tp =
+    concat
+      [ "Cannot produce a lexer combinator for function: "
+      , nameBase x
+      , "."
+      , "\n This is because the type: `"
+      , pprint tp
+      , "` cannot be used to give a precise combinator, either because it does not refer to "
+      , "any fields of a `Lexer`, or because it ambiguously refers to many fields of a `Lexer`."
+      , "\n Some fields of the `Lexer` share the same type, so there are multiple possible candidate combinators for a particular field."
+      , " For example: "
+      , "\n   - `decimal`, `hexadecimal`,... all have type `IntegerParsers canHold -> Parsec Integer`."
+      , "\n   - `ascii`, `unicode`, ... all have type `TextParsers t -> Parsec t`."
+      ]
+
+---------------------------------------------------------------------------------------------------
+-- Util functions
+
+{-|
+Denote the type of an arrow; it is either normal or linear.
+-}
+type ArrowTp :: *
+data ArrowTp = StdArrow | LinearArrow
+
+{-|
+Get the domain of a function type.
+Keep any prefixed constraints and type variable quantifiers as a prefixing function.
+-}
+fnTpDomain
+  :: Type
+  -> Q (Type -> Type, Type, ArrowTp, Type)
+-- The head of the type, includes any preceding constraints
+-- and foralls. this is a function which prefixes the given type with the constraints/foralls
+-- The domain and codomain of the type
+fnTpDomain x = do
+  (a, (b, c, d)) <- fnTpDomain' =<< sanitiseTypeStars x
+  return (removeUnusedTVars . a, b, c, d)
+ where
+  fnTpDomain' (ForallT bnds ctx tp) = do
+    bnds' <- sanitiseBndrStars bnds
+    first (ForallT bnds' ctx .) <$> fnTpDomain' tp
+  fnTpDomain' (ForallVisT bnds tp) = do
+    bnds' <- sanitiseBndrStars bnds
+    first (ForallVisT bnds' .) <$> fnTpDomain' tp
+  fnTpDomain' (AppT (AppT ArrowT a) b) =
+    return (id, (a, StdArrow, b))
+  fnTpDomain' (AppT (AppT MulArrowT a) b) =
+    return (id, (a, LinearArrow, b))
+  fnTpDomain' tp =
+    fail
+      ("Type of given function is not a function type: " ++ show tp)
+
+---------------------------------------------------------------------------------------------------
+-- Lexer Field
+
+{- |
+@a@ is a `LexerField` when it is the type of a component or subcomponent of the `Lexer` type.
+This includes things like `Lexeme` and `Symbol`.
+
+Avoid writing instances for:
+- IntegerParsers
+- TextParsers String
+
+As this leads to ambiguous projections if users try to generate combinators for, e.g., 'Lexer.decimal.
+There are two possible instances here, one for `integer`, the other for `natural`, and there is no way to disambiguate here.
+By avoiding writing these instances, we can give the user a more informative error message should they try this.
+-}
+type LexerField :: * -> Constraint
+class LexerField a where
+  project :: (a -> b) -> (Lexer -> b)
+
+type LexerProj :: * -> * -> *
+type LexerProj a b = (a -> b) -> (Lexer -> b)
+
+instance LexerField Lexer where
+  {-# INLINE project #-}
+  project :: (Lexer -> b) -> (Lexer -> b)
+  project = id
+
+---------------------------------------------------------------------------------------------------
+-- Lexemes
+
+instance LexerField Lexeme where
+  {-# INLINE project #-}
+  project :: (Lexeme -> b) -> (Lexer -> b)
+  project f = f . lexeme
+
+instance LexerField Symbol where
+  {-# INLINE project #-}
+  project :: (Symbol -> b) -> (Lexer -> b)
+  project f = f . symbol . lexeme
+
+instance LexerField Names where
+  {-# INLINE project #-}
+  project :: (Names -> b) -> (Lexer -> b)
+  project f = f . names . lexeme
+
+instance LexerField (TextParsers Char) where
+  {-# INLINE project #-}
+  project :: (TextParsers Char -> b) -> (Lexer -> b)
+  project f = f . charLiteral . lexeme
+
+---------------------------------------------------------------------------------------------------
+-- Space
+
+instance LexerField Space where
+  {-# INLINE project #-}
+  project :: (Space -> b) -> (Lexer -> b)
+  project f = f . space

--- a/src/Text/Gigaparsec/Internal/Token/Patterns/LexerCombinators.hs
+++ b/src/Text/Gigaparsec/Internal/Token/Patterns/LexerCombinators.hs
@@ -75,7 +75,11 @@ import Text.Gigaparsec.Internal.TH.VersionAgnostic (Name)
 import Text.Gigaparsec.Token.Lexer qualified as Lexer
 
 {-|
-Generates the specified lexer combinators using the quoted lexer.
+Generates the specified lexer combinators using a quoted `Lexer`, for example, @[|lexer|]@.
+
+The generated combinators will behave like their counterparts in "Text.Gigaparsec.Token.Lexer", 
+except they won't require a lexer (or subcomponents thereof) to be supplied as an argument.
+
 
 ==== __Usage:__
 
@@ -95,15 +99,20 @@ These will behave like their counterparts in "Text.Gigaparsec.Token.Lexer", exce
 a 'Lexer' (or its subcomponents) as an argument.
 
 @since 0.4.0.0
+
 -}
 lexerCombinators
-  :: Q Exp -- The lexer
-  -> [Name] -- The combinators to generate
-  -> Q [Dec]
+  :: Q Exp   -- ^ The quoted 'Lexer'.
+  -> [Name]  -- ^ The combinators to generate.
+  -> Q [Dec] -- ^ Definitions of the generated combinators.
 lexerCombinators lexer ns = lexerCombinatorsWithNames lexer (zip ns (map nameBase ns))
 
 {-|
-Generates the specified lexer combinators with the specified names using the quoted lexer.
+Generates the specified lexer combinators with the given names using a quoted `Lexer`, for example, @[|lexer|]@.
+
+The generated combinators will behave like their counterparts in "Text.Gigaparsec.Token.Lexer", 
+except they won't require a lexer (or subcomponents thereof) to be supplied as an argument.
+
 
 ==== __Usage:__
 
@@ -121,11 +130,12 @@ These will behave like their counterparts in "Text.Gigaparsec.Token.Lexer", exce
 a 'Lexer' (or its subcomponents) as an argument.
 
 @since 0.4.0.0
+
 -}
-lexerCombinatorsWithNames ::
-  Q Exp -> -- The lexer
-  [(Name, String)] -> -- The combinators to generate
-  Q [Dec]
+lexerCombinatorsWithNames 
+  :: Q Exp            -- ^ The quoted `Lexer`.
+  -> [(Name, String)] -- ^ The combinators to generate with the given name.
+  -> Q [Dec]          -- ^ Definitions of the generated combinators.
 lexerCombinatorsWithNames lexer = fmap concat . traverse (uncurry (lexerCombinatorWithName lexer))
 
 {-|
@@ -144,16 +154,16 @@ lexerCombinatorWithName lexer old nm = do
 Constructs the combinator using the given type.
 Calculates the definition of the combinator using a typeclass (if possible).
 -}
-mkLexerCombinatorDec ::
+mkLexerCombinatorDec
   -- | The quoted Lexer
-  Q Exp ->
+  :: Q Exp
   -- | The name of the combinator to generate
-  String ->
+  -> String
   -- | The quoted name of the original combinator
-  Name ->
+  -> Name
   -- | The return type of the new combinator
-  Type ->
-  Q [Dec]
+  -> Type
+  -> Q [Dec]
 mkLexerCombinatorDec lexer nm old tp = do
   newX <- newName nm
   oldDocs <- getDoc (DeclDoc old)
@@ -167,20 +177,21 @@ mkLexerCombinatorDec lexer nm old tp = do
 
 {-| 
 Constructs the combinator using the given type.
-Calculates the definition of the combinator using a typeclass (if possible).
+Calculates the definition of the combinator using the `LexerField` typeclass (if possible).
 -}
-mkLexerCombinatorDecWithProj ::
+mkLexerCombinatorDecWithProj 
   -- | The quoted Lexer
-  Q Exp ->
+  :: Q Exp
   -- | The name of the combinator to generate
-  String ->
+  -> String
   -- | @old@, The quoted name of the original combinator
-  Name ->
+  -> Name
   -- | The return type of the new combinator
-  Q Type ->
+  -> Q Type
   -- | projection to precompose the @old@ combinator with
-  Q Exp ->
-  Q (Name, [Dec]) -- The name of the new combinator and its declaration
+  -> Q Exp
+  -- | The name of the new combinator and its declaration
+  -> Q (Name, [Dec]) 
 mkLexerCombinatorDecWithProj lexer nm old tp proj = do
   newX <- newName nm
   oldDocs <- getDoc (DeclDoc old)

--- a/src/Text/Gigaparsec/Token/Patterns.hs
+++ b/src/Text/Gigaparsec/Token/Patterns.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE TemplateHaskell, TypeOperators #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
 {-|
 Module      : Text.Gigaparsec.Token.Patterns
 Description : Template Haskell generators to help with patterns
@@ -12,13 +15,93 @@ of Haskell, or the extensions enabled. Please report any issues to the maintaine
 
 @since 0.2.2.0
 -}
-module Text.Gigaparsec.Token.Patterns (overloadedStrings) where
+module Text.Gigaparsec.Token.Patterns (
+  -- * Overloaded Strings
+  overloadedStrings,
+  -- * Lexer Combinators
+  {-|
+  These functions will generate combinators for parsing things like identifiers, keywords, etc,
+  as described by a 'Lexer'.
+
+  The combinators will behave like their counterparts in "Text.Gigaparsec.Token.Lexer",
+  except they do not need to be given a lexer(/a subcomponent of a lexer) as an argument.
+  
+  * 'lexerCombinators' will generate these lexer combinators using the same name as the original combinators.
+  * 'lexerCombinatorsWithNames' lets you rename the generated combinator; otherwise it behaves exactly as 'lexerCombinators'.
+
+  The combinators for numeric literals need their own generation function `generateIntegerParsers`.
+  If you try to generate a `Text.Gigaparsec.Token.Lexer.decimal` parser using `lexerCombinators`,
+  you will get an error!
+  
+  ==== __Examples:__
+
+  The combinator "Text.Gigaparsec.Token.Lexer.identifier" is used for parsing identifiers, and has the type,
+
+  > Lexer.identifier :: Lexer -> Parsec String
+
+  It is annoying to have to feed the lexer as the initial argument, as this will be fixed throughout the parser.
+  Usually, one ends up writing their own combinator:
+
+  > identifier :: Parsec String
+  > identifier = Lexer.identifier lexer
+
+  Writing these by hand is tedious; especially if we wish to use multiple such combinators.
+  This is where `lexerCombinators` comes in:
+
+  > $(lexerCombinators [| lexer |] ['Lexer.identifier])
+
+  will generate the combinator,
+
+  > identifier :: Parsec String
+  > identifier = Lexer.identifier lexer
+
+  If we wish to use multiple combinators, we just add each one to the list.
+  For example,
+
+  > $(lexerCombinators [| lexer |] ['Lexer.identifier, 'Lexer.fully, 'Lexer.softKeyword, 'Lexer.softOperator])
+
+
+  -}
+  lexerCombinators,
+  lexerCombinatorsWithNames,
+  -- ** Integer Parsers
+  generateIntegerParsers,
+  -- *** IntegerParserConfig
+  IntegerParserConfig,
+  prefix, widths, bases, includeUnbounded, signedOrUnsigned, collatedParser,
+  -- **** Presets
+  emptyIntegerParserConfig,
+  emptySignedIntegerParserConfig,
+  emptyUnsignedIntegerParserConfig,
+  -- **** Associated Types
+  SignedOrUnsigned(..),
+  IntLitBases(..),
+  IntLitBase(..),
+  ) where
 
 import Text.Gigaparsec (Parsec)
-import Text.Gigaparsec.Token.Lexer (lexeme, sym)
+import safe Text.Gigaparsec.Internal.Token.Lexer
+    ( Lexeme(sym),
+      Lexer(lexeme) )
+import safe Text.Gigaparsec.Internal.Token.Patterns.IntegerParsers
+    ( IntegerParserConfig(collatedParser, prefix, widths, bases,
+                          includeUnbounded, signedOrUnsigned),
+      SignedOrUnsigned(..),
+      IntLitBases(..),
+      IntLitBase(..),
+      generateIntegerParsers,
+      emptyIntegerParserConfig,
+      emptySignedIntegerParserConfig,
+      emptyUnsignedIntegerParserConfig )
+
 
 import Data.String (IsString(fromString))
-import Language.Haskell.TH.Syntax (Q, Dec, Exp)
+import Language.Haskell.TH.Syntax (Q, Dec (..), Exp)
+
+
+
+
+import Text.Gigaparsec.Internal.Token.Patterns.LexerCombinators (lexerCombinators, lexerCombinatorsWithNames)
 
 {-|
 When given a quoted reference to a 'Text.Gigaparsec.Token.Lexer.Lexer', for example
@@ -34,3 +117,4 @@ overloadedStrings qlexer = [d|
     instance u ~ () => IsString (Parsec u) where
       fromString = sym (lexeme $qlexer) -- TODO: one day, $qlexer.lexeme.sym
   |]
+

--- a/src/Text/Gigaparsec/Token/Patterns.hs
+++ b/src/Text/Gigaparsec/Token/Patterns.hs
@@ -31,7 +31,7 @@ module Text.Gigaparsec.Token.Patterns (
 
   The combinators for numeric literals need their own generation function `generateIntegerParsers`.
   If you try to generate a `Text.Gigaparsec.Token.Lexer.decimal` parser using `lexerCombinators`,
-  you will get an error!
+  you will get an error.
   
   ==== __Examples:__
 
@@ -75,7 +75,7 @@ module Text.Gigaparsec.Token.Patterns (
   emptyUnsignedIntegerParserConfig,
   -- **** Associated Types
   SignedOrUnsigned(..),
-  IntLitBases(..),
+  allBases,
   IntLitBase(..),
   ) where
 
@@ -87,7 +87,7 @@ import safe Text.Gigaparsec.Internal.Token.Patterns.IntegerParsers
     ( IntegerParserConfig(collatedParser, prefix, widths, bases,
                           includeUnbounded, signedOrUnsigned),
       SignedOrUnsigned(..),
-      IntLitBases(..),
+      allBases,
       IntLitBase(..),
       generateIntegerParsers,
       emptyIntegerParserConfig,

--- a/src/Text/Gigaparsec/Token/Patterns.hs
+++ b/src/Text/Gigaparsec/Token/Patterns.hs
@@ -28,10 +28,9 @@ module Text.Gigaparsec.Token.Patterns (
   
   * 'lexerCombinators' will generate these lexer combinators using the same name as the original combinators.
   * 'lexerCombinatorsWithNames' lets you rename the generated combinator; otherwise it behaves exactly as 'lexerCombinators'.
-
-  The combinators for numeric literals need their own generation function `generateIntegerParsers`.
-  If you try to generate a `Text.Gigaparsec.Token.Lexer.decimal` parser using `lexerCombinators`,
-  you will get an error.
+  * 'generateIntegerParsers' will generate lexer combinators for integer literals.
+    If you try to generate a `Text.Gigaparsec.Token.Lexer.decimal` parser using `lexerCombinators` or `lexerCombinatorsWithNames`,
+    you will get an error.
   
   ==== __Examples:__
 


### PR DESCRIPTION
Closes #56 and #55 (the latter was needed when testing the integer combinators).

Provides three functions:

- `lexerCombinators`
- `lexerCombinatorsWithNames`
- `generateIntegerParsers` 

Which generate analogues of the combinators in `Token.Lexer` which have their input `Lexer` (or a subcomponent thereof) fixed. For example,
```haskell
$(lexerCombinators [| lexer |] ['Lexer.identifier, 'Lexer.fully])
```
will generate,
```haskell
{-# INLINE identifier #-}
identifier :: Parsec String
{-# INLINE fully #-}
fully :: ∀ a . Parsec a -> Parsec a
```

#### Integer Parsers
The following is copied from the haddock documentation for how to use the integer lexer generators.

First, the config must be defined in another module. You can define multiple configs in the same module, as long as they are used in a different module.
```haskell
{-# LANGUAGE TemplateHaskell, OverloadedLists #-}
module IntegerConfigs where
…
uIntCfg :: IntegerParserConfig
uIntCfg = emptyUnsignedIntegerParserConfig {
    prefix = "u",
    widths = [(B8, [t| Word8 |]), (B32, [t| Word32 |])],
    bases = [Hexadecimal, Decimal, Binary],
    includeUnbounded = False,
    signedOrUnsigned = Unsigned,
    collatedParser = Just "natural"
  }
```
Then, we can feed this config, along with a quoted lexer, to `generateIntegerParsers`:

```haskell
{-# LANGUAGE TemplateHaskell #-}
module Lexer where
import IntegerConfigs (uIntCfg)
…
lexer :: Lexer
lexer = …

$(generateIntegerParsers [| lexer |] uIntCfg)
```
This will generate the following combinators,
```haskell
   ubinary8 :: Parsec Word8
   udecimal8 :: Parsec Word8
   uhexadecimal8 :: Parsec Word8
   ubinary32 :: Parsec Word32
   udecimal3 :: Parsec Word32
   uhexadecimal32 :: Parsec Word32
   natural8 :: Parsec Word8
   natural32 :: Parsec Word32
```


### Internal Details
#### Figuring out how to fix the first argument of the combinator
Define a type class `LexerField a` with a projection function `(a -> b) -> Lexer -> a`, which describes how to apply a function on`a`s to a lexer. One example is `LexerField Names`, where `project f = f . names . lexeme`. 

This is used when generating the combinators, so that we don't have to manually pattern match on the type of the combinator we are generating; we let the constraint solver figure it out for us. These instances are all inlined to ensure that the generated combinators do not use needless indirection.

#### Generated Declarations
The type signatures are necessary for some combinators, due to constraints that ghc can't infer. This means we need to reconstruct the type of the combinator by removing the domain type.

For example,  `Lexer.identifier :: Name -> Parsec String` should produce `identifier :: Parsec String`. This gets slightly complex if there are quantifiers in the type, say, `Lexer.alter :: ∀ a . Space -> CharPredicate -> Parsec a -> Parsec a`, as we then need to preserve these in the generated `alter :: ∀ a . CharPredicate -> Parsec a -> Parsec a`.

Even more tricky was constructing the types for the bounded integer parsers.
Consider, 
```haskell
Lexer.decimal8 :: forall a canHold. canHold 'B8 a => IntegerParsers canHold -> Parsec a
```
The generated combinator (with a specific config, and for signed numbers) should have the type,
```haskell
decimal8 :: Parsec Int8
```
If we simply preserved the quantifiers, we would get the type,
```haskell
decimal8 :: forall a canHold. canHold 'B8 a => Parsec Int8
```
The current solution involves checking if a bound type variable actually occurs free in the codomain (for a `LexerField a`, this is `b` in the field `a -> b`), and removing all variables that do not.
Perhaps this could be improved by performing a type substitution, perhaps using [th-abstraction](https://hackage.haskell.org/package/th-abstraction-0.2.8.0/docs/Language-Haskell-TH-Datatype.html#v:applySubstitution).